### PR TITLE
Display an error if uploaded file can't be read as CSV

### DIFF
--- a/src/components/FileUploadForm.vue
+++ b/src/components/FileUploadForm.vue
@@ -167,6 +167,8 @@ export default Vue.extend({
       } catch (err) {
         if (err.status === 409) {
           this.tableCreationError = `Table "${fileName}" already exists`;
+        } else if (err.status === 415) {
+          this.tableCreationError = 'Data could not be read as CSV';
         } else {
           this.tableCreationError = 'Unknown error; please see developer console for details';
           throw err;


### PR DESCRIPTION
This can happen if, e.g., someone renames a non-CSV file with a .csv extension then attempts to upload it.

Depends on https://github.com/multinet-app/multinet-server/pull/355
Closes #20 