### PR TITLE
Improved UX for deleting Workspaces/Tables/Graphs

### DIFF
--- a/src/components/DeleteGraphDialog.vue
+++ b/src/components/DeleteGraphDialog.vue
@@ -10,13 +10,13 @@
         <template v-slot:activator="{ on: tooltip }">
           <v-scroll-x-transition>
             <v-btn
+              class="ml-1"
               icon
               small
-              text
               @click="dialog.click"
               v-on="tooltip"
               >
-              <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
+              <v-icon color="red accent-3" size="20px">delete_sweep</v-icon>
             </v-btn>
           </v-scroll-x-transition>
         </template>

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -10,13 +10,13 @@
         <template v-slot:activator="{ on: tooltip }">
           <v-scroll-x-transition>
             <v-btn
+              class="ml-1"
               icon
               small
-              text
               @click="dialog.click"
               v-on="tooltip"
               >
-              <v-icon color="red accent-3" size="22px">delete_sweep</v-icon>
+              <v-icon color="red accent-3" size="20px">delete_sweep</v-icon>
             </v-btn>
           </v-scroll-x-transition>
         </template>

--- a/src/components/DownloadDialog.vue
+++ b/src/components/DownloadDialog.vue
@@ -12,11 +12,10 @@
             <v-btn
               icon
               small
-              text
               @click="dialog.click"
               v-on="tooltip"
             >
-              <v-icon color="primary" size="22px">save_alt</v-icon>
+              <v-icon color="primary" size="20px">save_alt</v-icon>
             </v-btn>
           </v-scroll-x-transition>
         </template>

--- a/src/components/GraphDialog.vue
+++ b/src/components/GraphDialog.vue
@@ -6,14 +6,12 @@
     <template v-slot:activator="{ on }">
       <v-btn
         id="add-graph"
-        class="new-button"
         color="blue darken-2"
-        fab
-        dark
+        icon
         medium
         v-on="on"
       >
-        <v-icon dark>add</v-icon>
+        <v-icon dark>add_circle</v-icon>
       </v-btn>
     </template>
     <v-card>

--- a/src/components/ItemPanel.vue
+++ b/src/components/ItemPanel.vue
@@ -55,6 +55,21 @@
               <v-list-item-title>{{item}}</v-list-item-title>
             </v-list-item-content>
 
+            <v-item-action
+              @click.prevent
+              v-if="hover"
+            >
+              <v-btn
+                icon
+              >
+                <v-icon color="primary">save_alt</v-icon>
+              </v-btn>
+              <v-btn
+                icon
+              >
+                <v-icon color="red accent-3">delete</v-icon>
+              </v-btn>
+            </v-item-action>
           </v-list-item>
         </v-hover>
       </v-list-item-group>

--- a/src/components/ItemPanel.vue
+++ b/src/components/ItemPanel.vue
@@ -27,34 +27,37 @@
     <v-divider></v-divider>
 
     <template v-if="items.length > 0">
-      <v-hover
-        v-for="item in items"
-        :key="item"
-      >
-        <v-list-item
-          active-class="grey lighten-4"
-          ripple
-          slot-scope="{ hover }"
-          :to="`/workspaces/${workspace}/${routeType}/${item}`"
+      <v-list-item-group color="primary">
+        <v-hover
+          v-for="item in items"
+          :key="item"
         >
-          <v-list-item-action @click.prevent>
-            <v-icon
-              color="blue lighten-1"
-              v-if="!hover && !checkbox[item]"
-            >{{icon}}</v-icon>
+          <v-list-item
+            active-class="grey lighten-4"
+            ripple
+            slot-scope="{ hover }"
+            :to="`/workspaces/${workspace}/${routeType}/${item}`"
+          >
+            <v-list-item-action @click.prevent>
+              <v-icon
+                class="item-icon"
+                v-if="!hover && !checkbox[item]"
+              >{{icon}}</v-icon>
 
-            <v-checkbox
-              class="ws-detail-checkbox"
-              v-else
-              v-model="checkbox[item]"
-            ></v-checkbox>
-          </v-list-item-action>
+              <v-checkbox
+                class="ws-detail-checkbox"
+                v-else
+                v-model="checkbox[item]"
+              ></v-checkbox>
+            </v-list-item-action>
 
-          <v-list-item-content>
-            <v-list-item-title>{{item}}</v-list-item-title>
-          </v-list-item-content>
-        </v-list-item>
-      </v-hover>
+            <v-list-item-content>
+              <v-list-item-title>{{item}}</v-list-item-title>
+            </v-list-item-content>
+
+          </v-list-item>
+        </v-hover>
+      </v-list-item-group>
     </template>
     <div
       class="ws-detail-empty-list"
@@ -136,4 +139,9 @@ export default Vue.extend({
   padding: 40px 40px 55px;
   text-align: center;
 }
+
+.item-icon {
+  opacity: .4;
+}
+
 </style>

--- a/src/components/ItemPanel.vue
+++ b/src/components/ItemPanel.vue
@@ -9,17 +9,17 @@
 
       <v-spacer />
 
-      <slot name="downloader"
-        :selection="selection"
-        :workspace="workspace"
-      >
-      </slot>
-      <slot name="deleter"
-        :selection="selection"
-        :workspace="workspace"
-      >
-      </slot>
+      <div class="actions mr-2 pr-3">
+        <slot name="downloader"
+          :selection="selection"
+          :workspace="workspace"
+        ></slot>
 
+        <slot name="deleter"
+          :selection="selection"
+          :workspace="workspace"
+        ></slot>
+      </div>
       <slot></slot>
 
     </v-subheader>
@@ -159,4 +159,7 @@ export default Vue.extend({
   opacity: .4;
 }
 
+.actions {
+  border-right: 1px solid #ccc;
+}
 </style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -87,6 +87,18 @@
               <v-list-item-content>
                 <v-list-item-title>{{space}}</v-list-item-title>
               </v-list-item-content>
+
+              <v-item-action
+                @click.prevent
+                v-if="hover"
+              >
+                <v-btn
+                  icon
+                  small
+                >
+                  <v-icon color="red accent-3" size="18">delete</v-icon>
+                </v-btn>
+              </v-item-action>
             </v-list-item>
           </v-hover>
         </v-list-item-group>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -61,33 +61,35 @@
       <v-divider></v-divider>
 
       <div class="workspaces">
-        <v-hover
-          v-for="space in workspaces"
-          :key="space"
-        >
-          <v-list-item
-            ripple
-            slot-scope="{ hover }"
-            :to="`/workspaces/${space}/`"
+        <v-list-item-group color="primary">
+          <v-hover
+            v-for="space in workspaces"
+            :key="space"
           >
-            <v-list-item-action @click.prevent>
-              <v-icon
-                color="primary"
-                v-if="!hover && !checkbox[space]"
-              >library_books</v-icon>
+            <v-list-item
+              ripple
+              slot-scope="{ hover }"
+              :to="`/workspaces/${space}/`"
+            >
+              <v-list-item-action @click.prevent>
+                <v-icon
+                  class="workspace-icon"
+                  v-if="!hover && !checkbox[space]"
+                >library_books</v-icon>
 
-              <v-checkbox
-                class="ws-checkbox"
-                v-else
-                v-model="checkbox[space]"
-              ></v-checkbox>
-            </v-list-item-action>
+                <v-checkbox
+                  class="ws-checkbox"
+                  v-else
+                  v-model="checkbox[space]"
+                ></v-checkbox>
+              </v-list-item-action>
 
-            <v-list-item-content>
-              <v-list-item-title>{{space}}</v-list-item-title>
-            </v-list-item-content>
-          </v-list-item>
-        </v-hover>
+              <v-list-item-content>
+                <v-list-item-title>{{space}}</v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+          </v-hover>
+        </v-list-item-group>
       </div>
     </v-list>
 
@@ -176,6 +178,10 @@ export default Vue.extend({
   /* 171px = height of app-bar + workspace button + list subheader */
   height: calc(100vh - 171px);
   overflow-y:scroll;
+}
+
+.workspace-icon {
+  opacity: .4;
 }
 </style>
 

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -6,14 +6,12 @@
     <template v-slot:activator="{ on }">
       <v-btn
         id="add-table"
-        class="new-button"
         color="blue darken-2"
-        fab
-        dark
+        icon
         medium
         v-on="on"
       >
-        <v-icon dark>add</v-icon>
+        <v-icon dark>add_circle</v-icon>
       </v-btn>
     </template>
     <v-card>


### PR DESCRIPTION
@waxlamp - I guess I need some help with the logic of this. For now it's just icons, but I want to be able to use the existing `DeleteGraphDialog.vue`, `DeleteTableDialog.vue` and `DeleteWorkspaceDialog.vue`. Couldn't quite figure out the logic to link it up, because the icon needs to be different. `delete_sweep` is being used for deleting selections and just `delete` will be used for individual items.

Closes #12