### PR TITLE
Add loading progress bar

### DIFF
--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -59,7 +59,7 @@
 
           </v-toolbar-title>
         </v-hover>
-
+        <v-progress-linear v-if="loading" indeterminate absolute bottom/>
         <v-spacer />
         <v-btn icon>
           <v-icon>more_vert</v-icon>
@@ -184,6 +184,7 @@ export default Vue.extend({
       nodeTables: [] as string[],
       edgeTables: [] as string[],
       graphs: [] as string[],
+      loading: false,
     };
   },
 
@@ -210,9 +211,11 @@ export default Vue.extend({
       let edgeTables;
 
       try {
+        this.loading = true;
         nodeTables = await api.tables(this.workspace, { type: 'node' });
         edgeTables = await api.tables(this.workspace, { type: 'edge' });
       } catch (err) {
+        this.loading = false;
         if (err.status === 404 && err.statusText === 'Workspace Not Found') {
           this.$router.replace({name: 'home'});
         } else {
@@ -231,6 +234,8 @@ export default Vue.extend({
       // Instruct both ItemPanels to clear their checkbox state.
       this.$refs.graphPanel.clearCheckboxes();
       this.$refs.tablePanel.clearCheckboxes();
+
+      this.loading = false;
     },
   },
   created() {


### PR DESCRIPTION
 Currently, when loading a workspace, there's a period of time where no graphs or tables appear, as that data is being fetched. This improves the UI a bit by adding a progress bar while this is happening.