### PR TITLE
Fix deletion api calls to order properly

### DIFF
--- a/src/components/DeleteGraphDialog.vue
+++ b/src/components/DeleteGraphDialog.vue
@@ -122,9 +122,7 @@ export default Vue.extend({
         workspace,
       } = this;
 
-      selection.forEach(async (graph) => {
-        await api.deleteGraph(workspace, graph);
-      });
+      await Promise.all(selection.map((graph) => api.deleteGraph(workspace, graph)));
 
       this.$emit('deleted');
       this.dialog = false;

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -164,9 +164,7 @@ export default Vue.extend({
         workspace,
       } = this;
 
-      selection.forEach(async (table) => {
-        await api.deleteTable(workspace, table);
-      });
+      await Promise.all(selection.map((table) => api.deleteTable(workspace, table)));
 
       this.$emit('deleted');
       this.dialog = false;

--- a/src/components/DeleteWorkspaceDialog.vue
+++ b/src/components/DeleteWorkspaceDialog.vue
@@ -120,9 +120,7 @@ export default Vue.extend({
         selection,
       } = this;
 
-      selection.forEach(async (ws) => {
-        await api.deleteWorkspace(ws);
-      });
+      await Promise.all(selection.map((ws) => api.deleteWorkspace(ws)));
 
       this.$emit('deleted');
       this.dialog = false;


### PR DESCRIPTION
This fixes a bug I just found/had encountered when doing the vuex stuff.

Before this change, this.$emit('deleted') would run right after
the forEach loop had finished kicking off asynchronous calls,
before they had finished. This lead to the fetching of new data
to happen in the middle of these deletion calls, which returned
incorrect/incomplete results.