### PR TITLE
Fix downloaders and lingering selection

### DIFF
--- a/src/components/DownloadDialog.vue
+++ b/src/components/DownloadDialog.vue
@@ -170,7 +170,7 @@ export default Vue.extend({
         URL.revokeObjectURL(link.href);
       }
 
-      this.$emit('downloaded');
+      this.$emit('downloaded', selection);
       this.loading = false;
       this.dialog = false;
     },

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -15,6 +15,7 @@
           :selection="selection"
           :workspace="workspace"
           download-type="graph"
+          @downloaded="cleanup"
         />
 
         <delete-graph-dialog
@@ -195,11 +196,11 @@ export default Vue.extend({
       });
     },
 
-    cleanup(deleted?: string[]) {
+    cleanup(selection?: string[]) {
       this.singleSelected = null;
 
-      if (deleted) {
-        deleted.forEach((item) => this.checkbox[item] = false);
+      if (selection) {
+        selection.forEach((item) => this.checkbox[item] = false);
       }
 
       this.$emit('update');

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -179,6 +179,12 @@ export default Vue.extend({
     },
   },
 
+  watch: {
+    workspace() {
+      this.clearCheckboxes();
+    },
+  },
+
   methods: {
     deleteItem(item: string) {
       this.singleSelected = item;

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -15,6 +15,7 @@
           :selection="selection"
           :workspace="workspace"
           download-type="table"
+          @downloaded="cleanup"
         />
 
         <delete-table-dialog
@@ -184,11 +185,11 @@ export default Vue.extend({
       });
     },
 
-    cleanup(deleted?: string[]) {
+    cleanup(selection?: string[]) {
       this.singleSelected = null;
 
-      if (deleted) {
-        deleted.forEach((item) => this.checkbox[item] = false);
+      if (selection) {
+        selection.forEach((item) => this.checkbox[item] = false);
       }
 
       this.$emit('update');

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -168,6 +168,12 @@ export default Vue.extend({
     },
   },
 
+  watch: {
+    workspace() {
+      this.clearCheckboxes();
+    },
+  },
+
   methods: {
     deleteItem(item: string) {
       this.singleSelected = item;

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -112,7 +112,6 @@ import GraphDialog from '@/components/GraphDialog.vue';
 import DeleteGraphDialog from '@/components/DeleteGraphDialog.vue';
 import TableDialog from '@/components/TableDialog.vue';
 import DeleteTableDialog from '@/components/DeleteTableDialog.vue';
-import DownloadDialog from '@/components/DownloadDialog.vue';
 import store from '@/store';
 
 const surroundingWhitespace = /^\s+|\s+$/;
@@ -130,7 +129,6 @@ export default Vue.extend({
     DeleteGraphDialog,
     TableDialog,
     DeleteTableDialog,
-    DownloadDialog,
   },
   props: {
     workspace: String as PropType<string>,


### PR DESCRIPTION
This probably just slipped through the cracks when we split up `ItemPanel`. If you'll notice, before this change, downloading a selection of tables/networks would keep the selection afterwards. 

Also, if you were to navigate to a different workspace after making a selection, that same selection would still be active on the second workspace, and would show up in the download/delete dialog.

This PR addresses both of these issues.