### PR TITLE
Update app config to link to Netlify

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,8 +14,7 @@
 import Sidebar from '@/components/Sidebar.vue';
 import Vue from 'vue';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const apps = require('./appregistry.json');
+import apps from './appregistry.json';
 
 export default Vue.extend({
   name: 'App',

--- a/src/appregistry.json
+++ b/src/appregistry.json
@@ -1,10 +1,10 @@
 [
     {
-        "name": "Nodelink",
-        "url": "http://multinet.app/nodelink"
+        "name": "Node-Link Diagram",
+        "url": "https://multinet-nodelink.netlify.com"
     },
     {
         "name": "Adjacency Matrix",
-        "url": "http://multinet.app/adjmatrix"
+        "url": "http://multinet-adjmatrix.netlify.com"
     }
 ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [


### PR DESCRIPTION
This PR does two things:
- switches the "app config" to be a build time, static operation
- changes the app config defaults to link to the view apps on Netlify (where they are now configured to deploy to automatically)