### PR TITLE
Bootstrap the app with current logged in user info

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@
 <script lang="ts">
 import Sidebar from '@/components/Sidebar.vue';
 import Vue from 'vue';
+import store from '@/store';
 
 import apps from './appregistry.json';
 
@@ -22,6 +23,10 @@ export default Vue.extend({
     return {
       apps,
     };
+  },
+
+  created() {
+    store.dispatch.fetchUserInfo();
   },
 });
 </script>


### PR DESCRIPTION
This fixes an error introduced in #80 during a merge commit.

The app was not showing that a logged in user was actually logged in; this solves that problem by forcing a check of the logged in user's information upon starting the app.