### PR TITLE
Update multinetjs version to 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "core-js": "^2.6.5",
     "direct-vuex": "^0.10.4",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.12.0",
+    "multinet": "0.13.0",
     "vue": "^2.6.10",
     "vue-gtag": "^1.2.1",
     "vue-router": "^3.0.2",


### PR DESCRIPTION
multinetjs 0.13.0 includes sending of credentials with all requests,
which is needed in order for the client to properly display the
logged-in user's readable workspaces.

This PR depends on https://github.com/multinet-app/multinetjs/pull/10.