### PR TITLE
Disable "new workspace" button when user is not logged in

### DIFF
--- a/src/components/WorkspaceDialog.vue
+++ b/src/components/WorkspaceDialog.vue
@@ -79,26 +79,6 @@
         </v-card>
       </v-dialog>
     </template>
-    <v-card>
-      <v-card-title class="get-started-title pb-2">
-        Getting Started
-      </v-card-title>
-      <v-card-text class="pb-5">
-        Click <strong>NEW WORKSPACE</strong> to create a workspace or select an existing one from the Workpaces list.
-      </v-card-text>
-      <v-divider />
-      <v-card-actions>
-        <v-spacer />
-        <v-btn
-          id="got-it"
-          color="primary"
-          small
-          @click="popover = false"
-        >
-          Got it!
-        </v-btn>
-      </v-card-actions>
-    </v-card>
   </v-menu>
 </template>
 

--- a/src/components/WorkspaceDialog.vue
+++ b/src/components/WorkspaceDialog.vue
@@ -1,6 +1,5 @@
 <template>
   <v-menu
-    v-model="popover"
     class="get-started"
     :close-on-content-click="false"
     max-width="275"
@@ -93,7 +92,6 @@ export default Vue.extend({
     return {
       dialog: false,
       newWorkspace: '',
-      popover: true,
       error: '',
     };
   },

--- a/src/components/WorkspaceDialog.vue
+++ b/src/components/WorkspaceDialog.vue
@@ -15,12 +15,17 @@
         width="500"
       >
         <template v-slot:activator="{ on }">
+          <!-- See
+            https://github.com/vuetifyjs/vuetify/issues/4482#issuecomment-476689473
+            for why the `dark` prop is tied to the disabled state of the button.
+          -->
           <v-btn
             id="add-workspace"
+            :disabled="userInfo == null"
             class="ws-btn ma-0 px-4 py-5"
             block
             color="grey darken-3"
-            dark
+            :dark="!!userInfo"
             depressed
             large
             v-on="on"
@@ -111,6 +116,10 @@ export default Vue.extend({
       popover: true,
       error: '',
     };
+  },
+
+  computed: {
+    userInfo: () => store.state.userInfo,
   },
 
   watch: {

--- a/src/components/WorkspaceDialog.vue
+++ b/src/components/WorkspaceDialog.vue
@@ -20,7 +20,7 @@
           -->
           <v-btn
             id="add-workspace"
-            :disabled="userInfo == null"
+            :disabled="userInfo === null"
             class="ws-btn ma-0 px-4 py-5"
             block
             color="grey darken-3"


### PR DESCRIPTION
This PR also removes the "intro" popover, as (1) it has become sort of annoying and (2) its advice no longer applies.

Since the way to really get started with this app is to create an account and log in, I'd like to find a UI design principle that makes the login mechanism more obvious and inviting (currently it's hidden behind a general "user account" badge).