### PR TITLE
Pass login tokens to the vis apps

### DIFF
--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -93,7 +93,7 @@
                 v-for="app in apps"
                 :key="app.name"
                 class="pl-2"
-                :href="`${app.url}/?workspace=${workspace}&graph=${graph}${loginToken}`"
+                :href="`${app.url}/?workspace=${workspace}&graph=${graph}#${loginToken}`"
                 target="_blank"
               >
                 <v-list-item-avatar class="mr-3">
@@ -387,7 +387,7 @@ export default Vue.extend({
       const token = getLoginToken();
 
       if (token !== null) {
-        return `&loginToken=${token}`;
+        return `loginToken=${token}`;
       }
 
       return '';

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -93,7 +93,7 @@
                 v-for="app in apps"
                 :key="app.name"
                 class="pl-2"
-                :href="`${app.url}/?workspace=${workspace}&graph=${graph}&token=${userToken}`"
+                :href="`${app.url}/?workspace=${workspace}&graph=${graph}${loginToken}`"
                 target="_blank"
               >
                 <v-list-item-avatar class="mr-3">
@@ -383,8 +383,14 @@ export default Vue.extend({
     drawerIcon(): string {
       return this.panelOpen ? 'expand_more' : 'expand_less';
     },
-    userToken() {
-      return getLoginToken();
+    loginToken(): string {
+      const token = getLoginToken();
+
+      if (token !== null) {
+        return `&loginToken=${token}`;
+      }
+
+      return '';
     },
   },
   watch: {

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -93,7 +93,7 @@
                 v-for="app in apps"
                 :key="app.name"
                 class="pl-2"
-                :href="`${app.url}/?workspace=${workspace}&graph=${graph}#${loginToken}`"
+                :href="`${app.url}/?workspace=${workspace}&graph=${graph}${loginToken}`"
                 target="_blank"
               >
                 <v-list-item-avatar class="mr-3">
@@ -387,7 +387,7 @@ export default Vue.extend({
       const token = getLoginToken();
 
       if (token !== null) {
-        return `loginToken=${token}`;
+        return `#loginToken=${token}`;
       }
 
       return '';

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -93,7 +93,7 @@
                 v-for="app in apps"
                 :key="app.name"
                 class="pl-2"
-                :href="`${app.url}/?workspace=${workspace}&graph=${graph}`"
+                :href="`${app.url}/?workspace=${workspace}&graph=${graph}&token=${userToken}`"
                 target="_blank"
               >
                 <v-list-item-avatar class="mr-3">
@@ -314,6 +314,7 @@ import Vue, { PropType } from 'vue';
 
 import api from '@/api';
 import { App } from '@/types';
+import { getLoginToken } from '@/utils/localStorage';
 
 export default Vue.extend({
   name: 'GraphDetail',
@@ -381,6 +382,9 @@ export default Vue.extend({
     },
     drawerIcon(): string {
       return this.panelOpen ? 'expand_more' : 'expand_less';
+    },
+    userToken() {
+      return getLoginToken();
     },
   },
   watch: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5852,10 +5852,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.16.0.tgz#7361fc87fbc84745f82f45bb8dd5ccd4d6a1f39b"
-  integrity sha512-aqbuRPG5XwGgK1ChhQwGmKkMJcrefbB7H0bKtLIU3OJp1iDwKSWhQ+wdfzPHvPweRt4f798suXdybN1v/uf8hw==
+multinet@0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.17.0.tgz#05b30b85d29af8cb877bed502d8cacdabe8796ed"
+  integrity sha512-EC+ALY7ciwSmbkC49NE5A0OmFYxjt/QrTPQf7sXDeL6FUi74UKaammlN3E11T4Pur3kNx686AycmKSbgCkPHNA==
   dependencies:
     axios "^0.19.0"
 


### PR DESCRIPTION
Closes #123

Adds logic to pass the login token from the main client to the vis apps via the querystring. 

I also had to update yarn.lock, since it wasn't updated in #122 after the version was bumped.