### PR TITLE
Add a "boolean" semantic type detection

### DIFF
--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -120,7 +120,7 @@ import { FileType, CSVColumnType } from '@/types';
 import { validFileType, fileName as getFileName, csvFileTypeRecommendations } from '@/utils/files';
 
 const defaultKeyField = '_key';
-const multinetTypes: readonly CSVColumnType[] = ['label', 'category', 'number', 'date'];
+const multinetTypes: readonly CSVColumnType[] = ['label', 'boolean', 'category', 'number', 'date'];
 const fileTypes: readonly FileType[] = [
   {
     extension: ['csv'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { UploadType } from 'multinet';
 
-export type CSVColumnType = 'label' | 'category' | 'number' | 'date';
+export type CSVColumnType = 'label' | 'boolean' | 'category' | 'number' | 'date';
 
 export interface App {
   name: string;

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -21,8 +21,16 @@ function isBoolean(strings: Set<string>) {
   const candidates: Array<[string, string]> = [
     ['0', '1'],
     ['no', 'yes'],
+    ['No', 'Yes'],
+    ['NO', 'YES'],
+    ['n', 'y'],
+    ['N', 'Y'],
     ['false', 'true'],
+    ['False', 'True'],
+    ['FALSE', 'TRUE'],
     ['off', 'on'],
+    ['Off', 'On'],
+    ['OFF', 'ON'],
   ];
 
   // Consider the string set to be compatible with the "boolean" semantic type

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -11,6 +11,26 @@ function validFileType(file: File, allowedTypes: readonly FileType[]) {
   return allowedTypes.some((type) => type.extension.includes(extension) && validUploadType(type.queryCall));
 }
 
+function isBoolean(strings: Set<string>) {
+  // This function tests wehther both elements of an array belong to the string
+  // set.
+  const hasPair = ([a, b]: [string, string]) => strings.has(a) && strings.has(b);
+
+  // This is a list of two-element arrays containing valid false/true value
+  // pairs.
+  const candidates: Array<[string, string]> = [
+    ['0', '1'],
+    ['no', 'yes'],
+    ['false', 'true'],
+    ['off', 'on'],
+  ];
+
+  // Consider the string set to be compatible with the "boolean" semantic type
+  // if it contains exactly two unique values, and that pair of values is
+  // precisely one of the candidate pairs above.
+  return strings.size === 2 && candidates.some(hasPair);
+}
+
 interface TypeScore {
   strings: Set<string>;
   number: number;
@@ -72,6 +92,7 @@ async function csvFileTypeRecommendations(file: File): Promise<Map<string, CSVCo
       complete: () => {
         columnTypes.forEach((entry, field) => {
           const isKey = field === '_key' || field === '_from' || field === '_to';
+          const boolean = isBoolean(entry.strings);
           const category = entry.strings.size <= 10;
           const number = entry.number === entry.total;
           const date = entry.date === entry.total;
@@ -79,6 +100,8 @@ async function csvFileTypeRecommendations(file: File): Promise<Map<string, CSVCo
           let rec: CSVColumnType = 'label';
           if (isKey) {
             rec = 'label';
+          } else if (boolean) {
+            rec = 'boolean';
           } else if (category && !number && !date) {
             rec = 'category';
           } else if (number) {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -12,7 +12,7 @@ function validFileType(file: File, allowedTypes: readonly FileType[]) {
 }
 
 function isBoolean(strings: Set<string>) {
-  // This function tests wehther both elements of an array belong to the string
+  // This function tests whether both elements of an array belong to the string
   // set.
   const hasPair = ([a, b]: [string, string]) => strings.has(a) && strings.has(b);
 


### PR DESCRIPTION
This PR adds a `boolean` semantic type to the ones detected at CSV upload time.

This works by detecting whether a column has exactly two unique values, and whether those two values are one of several possible pairs of boolean-indicative values. These include the strings `0` and `1` but also several of the YAML-compliant boolean values.

Some things I need feedback on:
- Currently, the heuristic does not allow for mix-and-match between the possible signal words--e.g., a column with `yes` for true and `0` for false, or a mix of `yes` and `true` for true, will NOT be detected as a boolean column. **Should we allow for a mix-and-match approach, or restrict to just a single pair of words?** (If we support "mix-and-match" then the heuristic will need to change slightly, but this is not a big deal.)
- If we do allow mix-and-match, should we support the full range of values given by the [YAML spec](https://yaml.org/type/bool.html)?
- How do we store these values in the database? My gut says we simply translate each word in the column into an Python/Arango-level `bool` value and store that. Then, clients will receive JSON boolean values and can interpret those how they wish.