### PR TITLE
Replace `<v-content>` with `<v-main>`

### DIFF
--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid>
-    <v-content>
+    <v-main>
       <v-navigation-drawer
         right
         app
@@ -113,7 +113,7 @@
           highlight-mouseover-node
         />
       </v-card>
-    </v-content>
+    </v-main>
   </v-container>
 </template>
 

--- a/src/views/FrontPage.vue
+++ b/src/views/FrontPage.vue
@@ -3,7 +3,7 @@
     class="pa-0"
     fluid
   >
-    <v-content>
+    <v-main>
       <!-- BANNER -->
       <v-responsive
         class="mb-5"
@@ -112,7 +112,7 @@
           </v-col>
         </v-row>
       </div>
-    </v-content>
+    </v-main>
   </v-container>
 </template>
 

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -44,7 +44,7 @@
         <v-icon>more_vert</v-icon>
       </v-btn>
     </v-app-bar>
-    <v-content class="fill-height">
+    <v-main class="fill-height">
       <v-container
         align-stretch
         d-flex
@@ -305,7 +305,7 @@
           </v-btn>
         </div>
       </v-container>
-    </v-content>
+    </v-main>
   </v-container>
 </template>
 

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -3,7 +3,7 @@
     class="node-container"
     fluid
   >
-    <v-content>
+    <v-main>
       <v-app-bar app>
         <v-toolbar-title class="ws-detail-title">
           <v-icon
@@ -234,7 +234,7 @@
           </v-col>
         </v-row>
       </v-container>
-    </v-content>
+    </v-main>
   </v-container>
 </template>
 

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -37,7 +37,7 @@
         </v-list>
       </v-list>
     </v-navigation-drawer>
-    <v-content class="ma-0">
+    <v-main class="ma-0">
       <v-app-bar
         app
         clipped-right
@@ -94,7 +94,7 @@
           :options.sync="pagination"
         />
       </div>
-    </v-content>
+    </v-main>
   </v-container>
 </template>
 

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid>
-    <v-content>
+    <v-main>
       <v-app-bar app>
         <v-hover>
           <v-toolbar-title
@@ -154,7 +154,7 @@
           </v-card>
         </v-flex>
       </v-layout>
-    </v-content>
+    </v-main>
   </v-container>
 </template>
 


### PR DESCRIPTION
This is in response to console warnings explaining that `<v-content>` is deprecated.

@jtomeck, could you verify that this change is the correct way to do things? I couldn't find a migration guide addressing this specifically, so I just followed the advice in the warning message itself (which just says to use `<v-main>` instead).