### PR TITLE
Add column type information to table creation call

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.19",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.18.0",
+    "multinet": "0.17.0-10-gdd226e8",
     "papaparse": "^5.3.0",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.19",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.17.0-11-g0c31902",
+    "multinet": "0.19.0",
     "papaparse": "^5.3.0",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.19",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.17.0-10-gdd226e8",
+    "multinet": "0.17.0-11-g0c31902",
     "papaparse": "^5.3.0",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.8.2",

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -264,6 +264,7 @@ export default defineComponent({
           data: selectedFile.value,
           key: keyField.value,
           overwrite: overwrite.value,
+          columnTypes: columnType.value,
         }, {
           onUploadProgress: handleUploadProgress,
         });

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -163,7 +163,7 @@ import {
 
 import api from '@/api';
 import { FileType, CSVColumnType } from '@/types';
-import { validFileType, fileName as getFileName, csvFileTypeRecommendations } from '@/utils/files';
+import { validFileType, fileName as getFileName, analyzeCSV } from '@/utils/files';
 
 const defaultKeyField = '_key';
 const multinetTypes: readonly CSVColumnType[] = ['label', 'boolean', 'category', 'number', 'date'];
@@ -221,12 +221,12 @@ export default defineComponent({
         fileUploadError.value = null;
       }
 
-      const typeRecs = await csvFileTypeRecommendations(file);
-      columnType.value = Array.from(typeRecs.typeRecs.keys()).reduce(
-        (acc, key) => ({ ...acc, [key]: typeRecs.typeRecs.get(key) }), {},
+      const analysis = await analyzeCSV(file);
+      columnType.value = Array.from(analysis.typeRecs.keys()).reduce(
+        (acc, key) => ({ ...acc, [key]: analysis.typeRecs.get(key) }), {},
       );
 
-      sampleRows.value = [...typeRecs.sampleRows];
+      sampleRows.value = [...analysis.sampleRows];
     }
 
     // Upload options

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -189,12 +189,7 @@ export default defineComponent({
     const step: Ref<number> = ref(1);
     const rowSample: Ref<Array<{}>> = ref([]);
     const headers = computed(() => {
-      if (rowSample.value.length === 0) {
-        return [];
-      }
-
-      const keys = Object.keys(rowSample.value[0]);
-
+      const keys = Object.keys(rowSample.value[0] || {});
       return keys.map((key) => ({
         text: key,
         value: key,

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -115,7 +115,7 @@
             fixed-header
             :headers="headers"
             hide-default-header
-            :items="rowSample"
+            :items="sampleRows"
           >
             <template v-slot:header="{ props: { headers } }">
               <thead>
@@ -187,9 +187,9 @@ export default defineComponent({
   setup(props, { emit }) {
     // Stepper control
     const step: Ref<number> = ref(1);
-    const rowSample: Ref<Array<{}>> = ref([]);
+    const sampleRows: Ref<Array<{}>> = ref([]);
     const headers = computed(() => {
-      const keys = Object.keys(rowSample.value[0] || {});
+      const keys = Object.keys(sampleRows.value[0] || {});
       return keys.map((key) => ({
         text: key,
         value: key,
@@ -226,7 +226,7 @@ export default defineComponent({
         (acc, key) => ({ ...acc, [key]: typeRecs.typeRecs.get(key) }), {},
       );
 
-      rowSample.value = [...typeRecs.rowSample];
+      sampleRows.value = [...typeRecs.sampleRows];
     }
 
     // Upload options
@@ -279,7 +279,7 @@ export default defineComponent({
     return {
       step,
       headers,
-      rowSample,
+      sampleRows,
       columnType,
       multinetTypes,
       fileName,

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -46,13 +46,13 @@ interface TypeScore {
   total: number;
 }
 
-interface Recommendation {
+interface CSVAnalysis {
   typeRecs: Map<string, CSVColumnType>;
   sampleRows: Array<{}>;
 }
 
-async function csvFileTypeRecommendations(file: File): Promise<Recommendation> {
-  const parsePromise: Promise<Recommendation> = new Promise((resolve) => {
+async function analyzeCSV(file: File): Promise<CSVAnalysis> {
+  const parsePromise: Promise<CSVAnalysis> = new Promise((resolve) => {
     const columnTypes = new Map<string, TypeScore>();
     const typeRecs = new Map<string, CSVColumnType>();
     const sampleRows = [] as Array<{}>;
@@ -145,5 +145,5 @@ async function csvFileTypeRecommendations(file: File): Promise<Recommendation> {
 export {
   fileName,
   validFileType,
-  csvFileTypeRecommendations,
+  analyzeCSV,
 };

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -48,14 +48,14 @@ interface TypeScore {
 
 interface Recommendation {
   typeRecs: Map<string, CSVColumnType>;
-  rowSample: Array<{}>;
+  sampleRows: Array<{}>;
 }
 
 async function csvFileTypeRecommendations(file: File): Promise<Recommendation> {
   const parsePromise: Promise<Recommendation> = new Promise((resolve) => {
     const columnTypes = new Map<string, TypeScore>();
     const typeRecs = new Map<string, CSVColumnType>();
-    const rowSample = [] as Array<{}>;
+    const sampleRows = [] as Array<{}>;
 
     Papa.parse(file, {
       header: true,
@@ -64,8 +64,8 @@ async function csvFileTypeRecommendations(file: File): Promise<Recommendation> {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data = row.data as { [key: string]: any };
 
-        if (rowSample.length !== 30) {
-          rowSample.push({ ...data });
+        if (sampleRows.length !== 30) {
+          sampleRows.push({ ...data });
         }
 
         Object.keys(data).forEach((key: string) => {
@@ -133,7 +133,7 @@ async function csvFileTypeRecommendations(file: File): Promise<Recommendation> {
 
         resolve({
           typeRecs,
-          rowSample,
+          sampleRows,
         });
       },
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,10 +5871,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.17.0-11-g0c31902:
-  version "0.17.0-11-g0c31902"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.17.0-11-g0c31902.tgz#1818ee6bd6637f0f6615dad71806a0eb34276dbf"
-  integrity sha512-t0HMTILF45IGVbTTXFCMnp5XqA5vEQF1Y7v5OinJmaGuooLK59wMcHmLYU41vOthtGca/3S1vCPu6djp6xncMQ==
+multinet@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.19.0.tgz#99d7d319da67ab49fa2e6f0980b7022ff845fdc0"
+  integrity sha512-kBoDdgRGRYxBeAB/8PcTJdozP+xQpFARzd27FNZLKcq+FkFJdhXMCI5DQdWod6I4w4fX/qCm6zXIVO55c4eZ2w==
   dependencies:
     axios "^0.19.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,10 +5871,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.18.0.tgz#bc88f0fc980ddce18ba781962ef597788a1c26ec"
-  integrity sha512-rLO+5EH67kbiosN2DnEZLaKUa6VSNy/pm372EfZkn8JSMkwNK1SL7si6zpTfuXFA/QZIShlJmzRpD92+LZ6GQg==
+multinet@0.17.0-10-gdd226e8:
+  version "0.17.0-10-gdd226e8"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.17.0-10-gdd226e8.tgz#916113779f19f9c1e07a1f13ef590a372e721805"
+  integrity sha512-+pSVWMjzbtY7oBJ2t/9rTgbczN7ibSpbk1oCuV1ayhR2hAUc1W1r7v7ggjSPyt7qMMZC3jDanDxs0hKb1vWemA==
   dependencies:
     axios "^0.19.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,10 +5871,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.17.0-10-gdd226e8:
-  version "0.17.0-10-gdd226e8"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.17.0-10-gdd226e8.tgz#916113779f19f9c1e07a1f13ef590a372e721805"
-  integrity sha512-+pSVWMjzbtY7oBJ2t/9rTgbczN7ibSpbk1oCuV1ayhR2hAUc1W1r7v7ggjSPyt7qMMZC3jDanDxs0hKb1vWemA==
+multinet@0.17.0-11-g0c31902:
+  version "0.17.0-11-g0c31902"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.17.0-11-g0c31902.tgz#1818ee6bd6637f0f6615dad71806a0eb34276dbf"
+  integrity sha512-t0HMTILF45IGVbTTXFCMnp5XqA5vEQF1Y7v5OinJmaGuooLK59wMcHmLYU41vOthtGca/3S1vCPu6djp6xncMQ==
   dependencies:
     axios "^0.19.0"
 


### PR DESCRIPTION
This PR makes use of https://github.com/multinet-app/multinetjs/pull/22.

This uses the updated multinetjs library to send column type information at table upload time.

Depends on https://github.com/multinet-app/multinetjs/pull/22 being merged and released.
Depends on #136.