### PR TITLE
Display semantic types in table view

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.19",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.19.0-1-ge7b5794",
+    "multinet": "0.20.0",
     "papaparse": "^5.3.0",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.19",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.19.0",
+    "multinet": "0.19.0-1-ge7b5794",
     "papaparse": "^5.3.0",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.8.2",

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -185,15 +185,22 @@ export default Vue.extend({
   watch: {
     workspace() {
       this.update();
+      this.updateTypes();
     },
     table() {
       this.update();
+      this.updateTypes();
     },
 
     pagination() {
       this.update();
     },
   },
+
+  mounted() {
+    this.updateTypes();
+  },
+
   methods: {
     rowClassName(index: number): 'even-row' | 'odd-row' {
       return index % 2 === 0 ? 'even-row' : 'odd-row';
@@ -207,8 +214,6 @@ export default Vue.extend({
         offset: (pagination.page - 1) * pagination.itemsPerPage,
         limit: pagination.itemsPerPage,
       });
-
-      this.columnTypes = await api.tableColumnTypes(this.workspace, this.table);
 
       const {
         rows,
@@ -244,6 +249,10 @@ export default Vue.extend({
       this.tables = await api.tables(this.workspace, {
         type: 'all',
       });
+    },
+
+    async updateTypes() {
+      this.columnTypes = await api.tableColumnTypes(this.workspace, this.table);
     },
   },
 });

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -103,7 +103,9 @@
                   class="pt-2 pb-4"
                 >
                   {{ header.text }}
-                  <span>{{ columnTypes[header.text] ? `(${columnTypes[header.text]})` : "" }}</span>
+                  <span v-if="columnTypes[header.text]">
+                    ({{ columnTypes[header.text] }})
+                  </span>
                 </th>
               </tr>
             </thead>

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -85,6 +85,7 @@
           height="calc(100vh - 123px)"
           class="table-details"
           :headers="dataTableHeaders"
+          hide-default-header
           :items="dataTableRows"
           :footer-props="{
             itemsPerPageOptions: [10, 20, 50, 100],
@@ -92,7 +93,22 @@
           }"
           :server-items-length="tableSize"
           :options.sync="pagination"
-        />
+        >
+          <template v-slot:header>
+            <thead dark>
+              <tr>
+                <th
+                  v-for="(header, i) in dataTableHeaders"
+                  :key="i"
+                  class="pt-2 pb-4"
+                >
+                  {{ header.text }}
+                  <span>{{ columnTypes[header.text] ? `(${columnTypes[header.text]})` : "" }}</span>
+                </th>
+              </tr>
+            </thead>
+          </template>
+        </v-data-table>
       </div>
     </v-main>
   </v-container>
@@ -102,6 +118,7 @@
 import Vue, { PropType } from 'vue';
 
 import api from '@/api';
+import { ColumnTypes } from 'multinet';
 import { KeyValue, TableRow } from '@/types';
 
 interface DataPagination {
@@ -131,6 +148,7 @@ export default Vue.extend({
       rowKeys: [] as KeyValue[][],
       headers: [] as Array<keyof TableRow>,
       tables: [] as string[],
+      columnTypes: {} as ColumnTypes,
       editing: false,
       tableSize: 1,
       pagination: {} as DataPagination,
@@ -189,6 +207,8 @@ export default Vue.extend({
         offset: (pagination.page - 1) * pagination.itemsPerPage,
         limit: pagination.itemsPerPage,
       });
+
+      this.columnTypes = await api.tableColumnTypes(this.workspace, this.table);
 
       const {
         rows,

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -120,7 +120,6 @@
 import Vue, { PropType } from 'vue';
 
 import api from '@/api';
-import { ColumnTypes } from 'multinet';
 import { KeyValue, TableRow } from '@/types';
 
 interface DataPagination {
@@ -150,7 +149,6 @@ export default Vue.extend({
       rowKeys: [] as KeyValue[][],
       headers: [] as Array<keyof TableRow>,
       tables: [] as string[],
-      columnTypes: {} as ColumnTypes,
       editing: false,
       tableSize: 1,
       pagination: {} as DataPagination,
@@ -169,12 +167,13 @@ export default Vue.extend({
       }));
     },
 
-    dataTableRows() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dataTableRows(this: any) {
       const result = [] as TableRow[];
 
-      this.rowKeys.forEach((rowKey) => {
+      this.rowKeys.forEach((rowKey: KeyValue[]) => {
         const obj = {} as TableRow;
-        rowKey.forEach((entry) => {
+        rowKey.forEach((entry: KeyValue) => {
           obj[entry.key] = entry.value;
         });
 
@@ -184,30 +183,45 @@ export default Vue.extend({
       return result;
     },
   },
-  watch: {
-    workspace() {
-      this.update();
-      this.updateTypes();
-    },
-    table() {
-      this.update();
-      this.updateTypes();
-    },
 
-    pagination() {
-      this.update();
+  asyncComputed: {
+    columnTypes: {
+      async get() {
+        try {
+          return await api.tableColumnTypes(this.workspace, this.table);
+        } catch (err) {
+          return {};
+        }
+      },
+
+      default: {},
     },
   },
 
-  mounted() {
-    this.updateTypes();
+  watch: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    workspace(this: any) {
+      this.update();
+    },
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    table(this: any) {
+      this.update();
+    },
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    pagination(this: any) {
+      this.update();
+    },
   },
 
   methods: {
     rowClassName(index: number): 'even-row' | 'odd-row' {
       return index % 2 === 0 ? 'even-row' : 'odd-row';
     },
-    async update() {
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async update(this: any) {
       const {
         pagination,
       } = this;
@@ -251,10 +265,6 @@ export default Vue.extend({
       this.tables = await api.tables(this.workspace, {
         type: 'all',
       });
-    },
-
-    async updateTypes() {
-      this.columnTypes = await api.tableColumnTypes(this.workspace, this.table);
     },
   },
 });

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -100,7 +100,7 @@
                 <th
                   v-for="(header, i) in dataTableHeaders"
                   :key="i"
-                  class="pt-2 pb-4"
+                  class="pt-2 pb-2"
                 >
                   {{ header.text }}
                   <span v-if="columnTypes[header.text]">

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,10 +5871,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.19.0.tgz#99d7d319da67ab49fa2e6f0980b7022ff845fdc0"
-  integrity sha512-kBoDdgRGRYxBeAB/8PcTJdozP+xQpFARzd27FNZLKcq+FkFJdhXMCI5DQdWod6I4w4fX/qCm6zXIVO55c4eZ2w==
+multinet@0.19.0-1-ge7b5794:
+  version "0.19.0-1-ge7b5794"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.19.0-1-ge7b5794.tgz#9f9aaf4aa408927248f53555dce938a14e62846f"
+  integrity sha512-Kq08VOmpAc+HjHLFZYdv+P4bQN15LKoTs9Gb9hAGv//xqF428d0Y1jt+tTdY4xuLJRce/yn/yAx5ZTc13jtstQ==
   dependencies:
     axios "^0.19.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,10 +5871,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.19.0-1-ge7b5794:
-  version "0.19.0-1-ge7b5794"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.19.0-1-ge7b5794.tgz#9f9aaf4aa408927248f53555dce938a14e62846f"
-  integrity sha512-Kq08VOmpAc+HjHLFZYdv+P4bQN15LKoTs9Gb9hAGv//xqF428d0Y1jt+tTdY4xuLJRce/yn/yAx5ZTc13jtstQ==
+multinet@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.20.0.tgz#d81e26de386db1d61c9d76fcfdbc7540321273f0"
+  integrity sha512-vST7n2RsozEXHiwSpijgd14TuQTz0QznLVFsm3NIVgrDwLIfbfx2fXrFiiOizqkAN9KoSv0ZTbMrqYjtjTxSoA==
   dependencies:
     axios "^0.19.0"
 


### PR DESCRIPTION
This PR makes use of https://github.com/multinet-app/multinetjs/pull/23 to display the semantic types in the header row of the table view, if they exist.

@AlmightyYakob, could you make sure the code looks ok?

@jtomeck, could you take a look at design issues? The way I've done it works but I can tell it doesn't look/feel great.

Eventually, after migrations are implemented, we can dump the "if it exists" logic, since we can be confident that the type metadata will always exist.

TODO
- [ ] file issue to get rid of "if it exists" logic
- [x] force push the multinetjs version number after merging and publishing https://github.com/multinet-app/multinetjs/pull/23