### PR TITLE
Reset modals on successful completion

### DIFF
--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -183,6 +183,8 @@ export default Vue.extend({
 
       this.$emit('closed', [...selection]);
       this.dialog = false;
+      this.confirmation = '';
+      this.confirmationPhrase = randomPhrase();
     },
 
     async findDependentGraphs() {

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -263,6 +263,22 @@ export default defineComponent({
       uploadProgress.value = (evt.loaded / evt.total) * 100;
     }
 
+    // Reset component
+    function resetAllFields() {
+      step.value = 1;
+      columnType.value = {};
+
+      selectedFile.value = null;
+      fileName.value = null;
+      fileUploadError.value = null;
+
+      overwrite.value = false;
+      restoreKeyField();
+
+      uploading.value = false;
+      uploadProgress.value = null;
+    }
+
     // Table creation state
     const tableDialog = ref(false);
     const tableCreationError = ref<string | null>(null);
@@ -290,6 +306,7 @@ export default defineComponent({
         tableDialog.value = false;
 
         emit('success');
+        resetAllFields();
       } catch (err) {
         tableCreationError.value = err.statusText;
       } finally {


### PR DESCRIPTION
Closes #150

This fixes the bug in #150 that meant that the table upload dialog would not update between 2 table uploads.

I also noticed that the delete dialog wouldn't reset after a success, so I updated that to clear itself out and reset.