### PR TITLE
Add skeleton loaders across the app

### DIFF
--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -101,13 +101,19 @@
         </v-hover>
       </v-list-item-group>
     </template>
+
     <div
-      v-else
+      v-if="items.length === 0 && !loading"
       class="ws-detail-empty-list"
     >
       <v-icon color="blue lighten-1">
         info
       </v-icon> There's nothing here yet...
+    </div>
+
+    <div v-if="loading">
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
     </div>
   </v-list>
 </template>
@@ -147,6 +153,11 @@ export default Vue.extend({
 
     edgeTables: {
       type: Array as PropType<string[]>,
+      required: true,
+    },
+
+    loading: {
+      type: Boolean as PropType<boolean>,
       required: true,
     },
   },

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -38,7 +38,21 @@
 
     <v-divider />
 
-    <template v-if="items.length > 0">
+    <div v-if="loading">
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
+    </div>
+
+    <div
+      v-else-if="items.length === 0"
+      class="ws-detail-empty-list"
+    >
+      <v-icon color="blue lighten-1">
+        info
+      </v-icon> There's nothing here yet...
+    </div>
+
+    <template v-else>
       <v-list-item-group color="primary">
         <v-hover
           v-for="item in items"
@@ -101,20 +115,6 @@
         </v-hover>
       </v-list-item-group>
     </template>
-
-    <div
-      v-if="items.length === 0 && !loading"
-      class="ws-detail-empty-list"
-    >
-      <v-icon color="blue lighten-1">
-        info
-      </v-icon> There's nothing here yet...
-    </div>
-
-    <div v-if="loading">
-      <v-skeleton-loader type="list-item" />
-      <v-skeleton-loader type="list-item" />
-    </div>
   </v-list>
 </template>
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -107,6 +107,18 @@
             </v-list-item>
           </v-hover>
         </v-list-item-group>
+
+        <div v-if="loading">
+          <v-skeleton-loader
+            type="list-item"
+          />
+          <v-skeleton-loader
+            type="list-item"
+          />
+          <v-skeleton-loader
+            type="list-item"
+          />
+        </div>
       </div>
     </v-list>
   </v-navigation-drawer>
@@ -138,6 +150,7 @@ export default Vue.extend({
     return {
       newWorkspace: '',
       checkbox: {} as CheckboxTable,
+      loading: true,
       singleSelected: null as string | null,
     };
   },
@@ -171,8 +184,12 @@ export default Vue.extend({
     },
   },
 
-  created() {
-    store.dispatch.fetchWorkspaces();
+  async created() {
+    try {
+      await store.dispatch.fetchWorkspaces();
+    } finally {
+      this.loading = false;
+    }
   },
 
   methods: {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -109,15 +109,9 @@
         </v-list-item-group>
 
         <div v-if="loading">
-          <v-skeleton-loader
-            type="list-item"
-          />
-          <v-skeleton-loader
-            type="list-item"
-          />
-          <v-skeleton-loader
-            type="list-item"
-          />
+          <v-skeleton-loader type="list-item" />
+          <v-skeleton-loader type="list-item" />
+          <v-skeleton-loader type="list-item" />
         </div>
       </div>
     </v-list>

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -100,13 +100,21 @@
         </v-hover>
       </v-list-item-group>
     </template>
+
     <div
-      v-else
+      v-if="items.length === 0 && !loading"
       class="ws-detail-empty-list"
     >
       <v-icon color="blue lighten-1">
         info
       </v-icon> There's nothing here yet...
+    </div>
+
+    <div v-if="loading">
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
     </div>
   </v-list>
 </template>
@@ -136,6 +144,11 @@ export default Vue.extend({
 
     items: {
       type: Array as PropType<string[]>,
+      required: true,
+    },
+
+    loading: {
+      type: Boolean as PropType<boolean>,
       required: true,
     },
   },

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -37,7 +37,23 @@
 
     <v-divider />
 
-    <template v-if="items.length > 0">
+    <div v-if="loading">
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
+      <v-skeleton-loader type="list-item" />
+    </div>
+
+    <div
+      v-else-if="items.length === 0"
+      class="ws-detail-empty-list"
+    >
+      <v-icon color="blue lighten-1">
+        info
+      </v-icon> There's nothing here yet...
+    </div>
+
+    <template v-else>
       <v-list-item-group color="primary">
         <v-hover
           v-for="item in items"
@@ -100,22 +116,6 @@
         </v-hover>
       </v-list-item-group>
     </template>
-
-    <div
-      v-if="items.length === 0 && !loading"
-      class="ws-detail-empty-list"
-    >
-      <v-icon color="blue lighten-1">
-        info
-      </v-icon> There's nothing here yet...
-    </div>
-
-    <div v-if="loading">
-      <v-skeleton-loader type="list-item" />
-      <v-skeleton-loader type="list-item" />
-      <v-skeleton-loader type="list-item" />
-      <v-skeleton-loader type="list-item" />
-    </div>
   </v-list>
 </template>
 

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -136,6 +136,11 @@
                   color="transparent"
                   dense
                 >
+                  <div v-if="loading">
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
+                  </div>
+
                   <v-list-item
                     v-for="table in nodeTypes"
                     :key="table.name"
@@ -186,6 +191,11 @@
                   color="transparent"
                   dense
                 >
+                  <div v-if="loading">
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
+                  </div>
+
                   <v-list-item
                     v-for="table in edgeTypes"
                     :key="table.name"
@@ -274,6 +284,11 @@
                   color="transparent"
                   dense
                 >
+                  <div v-if="loading">
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
+                  </div>
+
                   <v-list-item
                     v-for="node in nodes"
                     :key="node"
@@ -344,6 +359,7 @@ export default Vue.extend({
       nodes: [] as string[],
       offset: 0,
       limit: 10,
+      loading: true,
       totalNodes: 0,
       totalEdges: 0,
       visItems: [...visItems],
@@ -405,6 +421,7 @@ export default Vue.extend({
       this.panelOpen = !this.panelOpen;
     },
     async update() {
+      this.loading = true;
       const graph = await api.graph(this.workspace, this.graph);
       const nodes = await api.nodes(this.workspace, this.graph, {
         offset: this.offset,
@@ -423,6 +440,7 @@ export default Vue.extend({
       this.nodes = nodes.nodes.map((d) => d._id);
       this.totalNodes = nodes.count;
       this.totalEdges = edges.reduce((acc, val) => acc + val, 0);
+      this.loading = false;
     },
     turnPage(forward: number) {
       this.offset += forward ? this.limit : -this.limit;

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -66,7 +66,13 @@
             cols="12"
             pa-4
           >
+            <v-skeleton-loader
+              v-if="loading"
+              type="image"
+            />
+
             <v-card
+              v-else
               color="primary"
               dark
             >
@@ -160,6 +166,21 @@
               </v-card-title>
               <v-card-text>
                 <v-list dense>
+                  <div v-if="loading">
+                    <v-skeleton-loader
+                      type="list-item"
+                      tile
+                    />
+                    <v-skeleton-loader
+                      type="list-item"
+                      tile
+                    />
+                    <v-skeleton-loader
+                      type="list-item"
+                      tile
+                    />
+                  </div>
+
                   <v-list-item
                     v-for="(edge, index) in incoming"
                     :key="index"
@@ -219,6 +240,21 @@
               </v-card-title>
               <v-card-text>
                 <v-list dense>
+                  <div v-if="loading">
+                    <v-skeleton-loader
+                      type="list-item"
+                      tile
+                    />
+                    <v-skeleton-loader
+                      type="list-item"
+                      tile
+                    />
+                    <v-skeleton-loader
+                      type="list-item"
+                      tile
+                    />
+                  </div>
+
                   <v-list-item
                     v-for="(edge, index) in outgoing"
                     :key="index"
@@ -291,6 +327,7 @@ export default Vue.extend({
       pageCount: 20,
       totalIncoming: 0,
       totalOutgoing: 0,
+      loading: true,
     };
   },
   computed: {
@@ -371,6 +408,7 @@ export default Vue.extend({
   },
   methods: {
     async update() {
+      this.loading = true;
       const attributes = await api.attributes(this.workspace, this.graph, `${this.type}/${this.node}`);
       const incoming = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
         direction: 'incoming',
@@ -392,6 +430,8 @@ export default Vue.extend({
       this.outgoing = outgoing.edges.map((edge: Edge) => ({ id: edge.edge, node: edge.to }));
       this.totalIncoming = incoming.count;
       this.totalOutgoing = outgoing.count;
+
+      this.loading = false;
     },
     turnPage(edgeType: EdgeType, forward: number) {
       if (edgeType === 'incoming') {

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -167,18 +167,9 @@
               <v-card-text>
                 <v-list dense>
                   <div v-if="loading">
-                    <v-skeleton-loader
-                      type="list-item"
-                      tile
-                    />
-                    <v-skeleton-loader
-                      type="list-item"
-                      tile
-                    />
-                    <v-skeleton-loader
-                      type="list-item"
-                      tile
-                    />
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
                   </div>
 
                   <v-list-item
@@ -241,18 +232,9 @@
               <v-card-text>
                 <v-list dense>
                   <div v-if="loading">
-                    <v-skeleton-loader
-                      type="list-item"
-                      tile
-                    />
-                    <v-skeleton-loader
-                      type="list-item"
-                      tile
-                    />
-                    <v-skeleton-loader
-                      type="list-item"
-                      tile
-                    />
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
+                    <v-skeleton-loader type="list-item" />
                   </div>
 
                   <v-list-item

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -18,6 +18,12 @@
 
           <v-divider />
 
+          <div v-if="loading">
+            <v-skeleton-loader type="list-item" />
+            <v-skeleton-loader type="list-item" />
+            <v-skeleton-loader type="list-item" />
+          </div>
+
           <v-list-item
             v-for="t in tables"
             :key="t"
@@ -93,6 +99,7 @@
           }"
           :server-items-length="tableSize"
           :options.sync="pagination"
+          :loading="loading"
         >
           <template v-slot:header>
             <thead dark>
@@ -152,6 +159,7 @@ export default Vue.extend({
       editing: false,
       tableSize: 1,
       pagination: {} as DataPagination,
+      loading: true,
     };
   },
   computed: {
@@ -226,6 +234,8 @@ export default Vue.extend({
         pagination,
       } = this;
 
+      this.loading = true;
+
       const result = await api.table(this.workspace, this.table, {
         offset: (pagination.page - 1) * pagination.itemsPerPage,
         limit: pagination.itemsPerPage,
@@ -265,6 +275,8 @@ export default Vue.extend({
       this.tables = await api.tables(this.workspace, {
         type: 'all',
       });
+
+      this.loading = false;
     },
   },
 });

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -133,6 +133,7 @@
               :items="graphs"
               :node-tables="nodeTables"
               :edge-tables="edgeTables"
+              :loading="loading"
             />
           </v-card>
         </v-flex>
@@ -150,6 +151,7 @@
             <table-panel
               :workspace="workspace"
               :items="tables"
+              :loading="loading"
             />
           </v-card>
         </v-flex>


### PR DESCRIPTION
Closes #147

Uses skeleton loaders across the app to give a more seamless experience. This new functionality means that the app doesn't load into an empty state and flip to the correct values.

There are a couple of issues I have regarding how many skeleton loaders to use for each piece, and there doesn't seem to be a way to change the color of the loaders. The number of loaders is a potential issue in most places and I'd like some feedback on how many you think I should use. Also, the colors are slightly different from the loaded version in just a couple of places, namely the NodeDetail panel and the table view when using skeleton loaders.

Let me know what you think. I'll add some screenshots below, but the deploy preview should give you a good example of how it will work in practice.

One final thing to consider, is what to do if the loading fails. Currently, it will just show skeleton loaders forever, which seems like an issue (aside from in the sidebar, where when it fails it will show nothing).

Workspaces sidebar:
![image](https://user-images.githubusercontent.com/36867477/110027937-dc4d1800-7cef-11eb-9321-bf1ad438c569.png)

Workspace overview:
![image](https://user-images.githubusercontent.com/36867477/110028014-f5ee5f80-7cef-11eb-910f-0acf2a758613.png)

Network overview:
![image](https://user-images.githubusercontent.com/36867477/110028159-2209e080-7cf0-11eb-9e90-748071dd28bc.png)

Table overview:
![image](https://user-images.githubusercontent.com/36867477/110028188-2afab200-7cf0-11eb-80a9-e1cee610cf2c.png)

Node overview (note the missing color from the large, full-width element on this screen):
![image](https://user-images.githubusercontent.com/36867477/110033123-351faf00-7cf6-11eb-9220-e896749f9ef5.png)