### PR TITLE
Add permissions check for creating networks and tables, disable menus

### DIFF
--- a/src/components/NetworkDialog.vue
+++ b/src/components/NetworkDialog.vue
@@ -9,6 +9,7 @@
         color="blue darken-2"
         icon
         medium
+        :disabled="!hasPerms"
         v-on="on"
       >
         <v-icon dark>
@@ -49,8 +50,12 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 
+import { WorkspacePermissionsSpec } from 'multinet';
 import NetworkCreateForm from '@/components/NetworkCreateForm.vue';
 import NetworkUploadForm from '@/components/NetworkUploadForm.vue';
+import api from '@/api';
+import { canUpload } from '@/utils/permissions';
+import store from '@/store';
 
 export default Vue.extend({
   name: 'NetworkDialog',
@@ -74,7 +79,24 @@ export default Vue.extend({
       networkDialog: false,
     };
   },
-  computed: {},
+  computed: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    hasPerms(this: any) {
+      return canUpload(store.state.userInfo, this.permissions);
+    },
+  },
+  asyncComputed: {
+    permissions: {
+      async get(): Promise<WorkspacePermissionsSpec | null> {
+        try {
+          return api.getWorkspacePermissions(this.workspace);
+        } catch (error) {
+          return null;
+        }
+      },
+      default: null,
+    },
+  },
   methods: {
     networkDialogSuccess() {
       this.networkDialog = false;

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -207,10 +207,10 @@ export default defineComponent({
     const { workspace } = props;
 
     // Check for permissions
-    const permissions = computed(async () => api.getWorkspacePermissions(workspace));
     const hasPerms = ref(false);
     watchEffect(async () => {
-      hasPerms.value = canUpload(store.state.userInfo, await permissions.value);
+      const perms = await api.getWorkspacePermissions(workspace);
+      hasPerms.value = canUpload(store.state.userInfo, perms);
     });
 
     // Stepper control

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -201,6 +201,8 @@ export default defineComponent({
     },
   },
   setup(props, { emit }) {
+    const { workspace } = props;
+
     // Stepper control
     const step: Ref<number> = ref(1);
     const dialogWidth = computed(() => {
@@ -296,7 +298,6 @@ export default defineComponent({
         return;
       }
 
-      const { workspace } = props;
       uploading.value = true;
 
       try {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -8,3 +8,16 @@ export enum RoleLevel {
   reader = 1,
   none = 0,
 }
+
+export function canUpload(userInfo: UserSpec | null, permissions: WorkspacePermissionsSpec | null): boolean {
+  if (!userInfo || !permissions) { return false; }
+
+  const userSub = userInfo.sub;
+  const ownerSub = permissions.owner.sub;
+  const maintainerSubs = permissions.maintainers.map((user) => user.sub);
+  const writerSubs = permissions.writers.map((user) => user.sub);
+
+  return maintainerSubs.includes(userSub)
+    || writerSubs.includes(userSub)
+    || userSub === ownerSub;
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,3 +1,5 @@
+import { UserSpec, WorkspacePermissionsSpec } from 'multinet';
+
 export type Role = 'owner' | 'maintainers' | 'writers' | 'readers';
 export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader' | null;
 
@@ -12,10 +14,10 @@ export enum RoleLevel {
 export function canUpload(userInfo: UserSpec | null, permissions: WorkspacePermissionsSpec | null): boolean {
   if (!userInfo || !permissions) { return false; }
 
-  const userSub = userInfo.sub;
-  const ownerSub = permissions.owner.sub;
-  const maintainerSubs = permissions.maintainers.map((user) => user.sub);
-  const writerSubs = permissions.writers.map((user) => user.sub);
+  const userSub = userInfo.username;
+  const ownerSub = permissions.owner.username;
+  const maintainerSubs = permissions.maintainers.map((user) => user.username);
+  const writerSubs = permissions.writers.map((user) => user.username);
 
   return maintainerSubs.includes(userSub)
     || writerSubs.includes(userSub)


### PR DESCRIPTION
Closes #83

Adds a permissions check for the buttons on the network panel, and disables the add table and add network button, if the user is not a writer of the workspace.

Signed in:
![image](https://user-images.githubusercontent.com/36867477/110194202-89a95400-7df4-11eb-98c0-458e748ed479.png)

Signed out:
![image](https://user-images.githubusercontent.com/36867477/110194213-9b8af700-7df4-11eb-815a-484d7aabd3ec.png)