### PR TITLE
Allow for `import` statement in dependent libraries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
 
   parserOptions: {
     parser: '@typescript-eslint/parser',
+    sourceType: 'module',
     ecmaVersion: 2020,
     ecmaFeatures: {
       modules: true,


### PR DESCRIPTION
Building the client shows an error about `import` being a reserved
keyword in the generated `multinetjs` library. Setting `sourceType` to
`"module"` fixes the problem.