### PR TITLE
Finish porting client to new backend

### DIFF
--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -203,13 +203,18 @@ export default Vue.extend({
         });
 
         // eslint-disable-next-line no-underscore-dangle
-        const prelimNodes = nodes.results.map((node) => node._id.substring(0, node._id.indexOf('/')));
-        const nodeTables = prelimNodes.filter((node, index) => prelimNodes.indexOf(node) === index);
+        const prelimNodes = nodes.results.map((node) => node._id.split('/')[0]);
+        const nodeTables = [];
+        prelimNodes.forEach((table) => {
+          if (!nodeTables.includes(table)) {
+            nodeTables.push(table);
+          }
+        });
         // eslint-disable-next-line no-underscore-dangle
-        const edgeTable = edges.results.length > 0 ? edges.results[0]._id.substring(0, edges.results[0]._id.indexOf('/')) : '';
+        const edgeTable = edges.results.length > 0 ? edges.results[0]._id.split('/')[0] : '';
         const tables: string[] = [];
         selection.forEach((table) => {
-          if (table === edgeTable || nodeTables.indexOf(table) > -1) {
+          if (table === edgeTable || nodeTables.includes(table)) {
             tables.push(table);
           }
         });

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -194,9 +194,9 @@ export default Vue.extend({
         workspace,
       } = this;
 
-      function tableName(table: TableRow) {
+      function tableName(tableRow: TableRow) {
         // eslint-disable-next-line no-underscore-dangle
-        return table._id.split('/')[0];
+        return tableRow._id.split('/')[0];
       }
 
       const graphNames = (await api.graphs(workspace)).results.map((graph) => graph.name);

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -113,6 +113,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { TableRow } from 'multinet';
 
 import api from '@/api';
 import { randomPhrase } from '@/utils/randomPhrase';
@@ -193,25 +194,27 @@ export default Vue.extend({
         workspace,
       } = this;
 
+      function tableName(table: TableRow) {
+        // eslint-disable-next-line no-underscore-dangle
+        return table._id.split('/')[0];
+      }
+
       const graphNames = (await api.graphs(workspace)).results.map((graph) => graph.name);
       const using = [] as Array<{graph: string; tables: string[]}>;
       graphNames.forEach(async (graph) => {
         const nodes = await api.nodes(workspace, graph, {});
-        // eslint-disable-next-line no-underscore-dangle
         const edges = await api.edges(workspace, graph, {
           direction: 'all',
         });
 
-        // eslint-disable-next-line no-underscore-dangle
-        const prelimNodes = nodes.results.map((node) => node._id.split('/')[0]);
+        const prelimNodes = nodes.results.map((node) => tableName(node));
         const nodeTables = [];
         prelimNodes.forEach((table) => {
           if (!nodeTables.includes(table)) {
             nodeTables.push(table);
           }
         });
-        // eslint-disable-next-line no-underscore-dangle
-        const edgeTable = edges.results.length > 0 ? edges.results[0]._id.split('/')[0] : '';
+        const edgeTable = edges.results.length > 0 ? tableName(edges.results[0]) : '';
         const tables: string[] = [];
         selection.forEach((table) => {
           if (table === edgeTable || nodeTables.includes(table)) {

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -198,7 +198,7 @@ export default Vue.extend({
       graphNames.forEach(async (graph) => {
         const nodes = await api.nodes(workspace, graph, {});
         // eslint-disable-next-line no-underscore-dangle
-        const edges = await api.edges(workspace, graph, nodes.results[0]._id, {
+        const edges = await api.edges(workspace, graph, {
           direction: 'all',
         });
 

--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -80,7 +80,7 @@ export default {
       const userInfo = this.userInfo as unknown as UserSpec | null;
 
       if (userInfo !== null) {
-        return `${userInfo.given_name[0]}${userInfo.family_name[0]}`;
+        return `${userInfo.first_name[0]}${userInfo.last_name[0]}`;
       }
       return '';
     },

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,4 @@
-export const host: string = process.env.VUE_APP_MULTINET_HOST || 'http://localhost:5000';
+export const host: string = process.env.VUE_APP_MULTINET_HOST || 'http://localhost:8000';
 export const gaTag: string = process.env.VUE_APP_GA_TAG || '';
 export const gitSha: string = process.env.VUE_APP_GIT_SHA || '';
 export const oauthApiRoot: string = process.env.VUE_APP_OAUTH_API_ROOT || `${host}/oauth/`;

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -422,9 +422,9 @@ export default Vue.extend({
       this.panelOpen = !this.panelOpen;
     },
     async update() {
-      function tableName(table: TableRow | EdgesSpec) {
+      function tableName(tableRow: TableRow | EdgesSpec) {
         // eslint-disable-next-line no-underscore-dangle
-        return table._id.split('/')[0];
+        return tableRow._id.split('/')[0];
       }
       this.loading = true;
       const graph = await api.graph(this.workspace, this.graph);

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -427,19 +427,22 @@ export default Vue.extend({
         offset: this.offset,
         limit: this.limit,
       });
-
-      const edgeQuery = `
-        FOR table in [${graph.edgeTable}]
-          RETURN LENGTH(table)
-      `;
-      const edges = await api.aql(this.workspace, edgeQuery);
-
-      this.nodeTypes = graph.nodeTables;
-      this.edgeTypes = [graph.edgeTable];
       // eslint-disable-next-line no-underscore-dangle
-      this.nodes = nodes.nodes.map((d) => d._id);
-      this.totalNodes = nodes.count;
-      this.totalEdges = edges.reduce((acc, val) => acc + val, 0);
+      const edges = await api.edges(this.workspace, this.graph, nodes.results[0]._id, {
+        offset: this.offset,
+        limit: this.limit,
+      });
+      this.totalNodes = graph.node_count;
+      this.totalEdges = graph.edge_count;
+
+      // eslint-disable-next-line no-underscore-dangle
+      const prelimNodes = nodes.results.map((node) => node._id.substring(0, node._id.indexOf('/')));
+      this.nodeTypes = prelimNodes.filter((node, index) => prelimNodes.indexOf(node) === index);
+      // eslint-disable-next-line no-underscore-dangle
+      this.edgeTypes = edges.results.length > 0 ? [edges.results[0]._id.substring(0, edges.results[0]._id.indexOf('/'))] : [];
+
+      // eslint-disable-next-line no-underscore-dangle
+      this.nodes = nodes.results.map((node) => node._id);
       this.loading = false;
     },
     turnPage(forward: number) {

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -326,6 +326,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { EdgesSpec, TableRow } from 'multinet';
 
 import api from '@/api';
 import { App } from '@/types';
@@ -421,13 +422,16 @@ export default Vue.extend({
       this.panelOpen = !this.panelOpen;
     },
     async update() {
+      function tableName(table: TableRow | EdgesSpec) {
+        // eslint-disable-next-line no-underscore-dangle
+        return table._id.split('/')[0];
+      }
       this.loading = true;
       const graph = await api.graph(this.workspace, this.graph);
       const nodes = await api.nodes(this.workspace, this.graph, {
         offset: this.offset,
         limit: this.limit,
       });
-      // eslint-disable-next-line no-underscore-dangle
       const edges = await api.edges(this.workspace, this.graph, {
         offset: this.offset,
         limit: this.limit,
@@ -435,15 +439,13 @@ export default Vue.extend({
       this.totalNodes = graph.node_count;
       this.totalEdges = graph.edge_count;
 
-      // eslint-disable-next-line no-underscore-dangle
-      const prelimNodes = nodes.results.map((node) => node._id.split('/')[0]);
+      const prelimNodes = nodes.results.map((node) => tableName(node));
       prelimNodes.forEach((nodeType) => {
         if (!this.nodeTypes.includes(nodeType)) {
           this.nodeTypes.push(nodeType);
         }
       });
-      // eslint-disable-next-line no-underscore-dangle
-      this.edgeTypes = edges.results.length > 0 ? [edges.results[0]._id.split('/')[0]] : [];
+      this.edgeTypes = edges.results.length > 0 ? [tableName(edges.results[0])] : [];
 
       // eslint-disable-next-line no-underscore-dangle
       this.nodes = nodes.results.map((node) => node._id);

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -428,7 +428,7 @@ export default Vue.extend({
         limit: this.limit,
       });
       // eslint-disable-next-line no-underscore-dangle
-      const edges = await api.edges(this.workspace, this.graph, nodes.results[0]._id, {
+      const edges = await api.edges(this.workspace, this.graph, {
         offset: this.offset,
         limit: this.limit,
       });

--- a/src/views/GraphDetail.vue
+++ b/src/views/GraphDetail.vue
@@ -436,10 +436,14 @@ export default Vue.extend({
       this.totalEdges = graph.edge_count;
 
       // eslint-disable-next-line no-underscore-dangle
-      const prelimNodes = nodes.results.map((node) => node._id.substring(0, node._id.indexOf('/')));
-      this.nodeTypes = prelimNodes.filter((node, index) => prelimNodes.indexOf(node) === index);
+      const prelimNodes = nodes.results.map((node) => node._id.split('/')[0]);
+      prelimNodes.forEach((nodeType) => {
+        if (!this.nodeTypes.includes(nodeType)) {
+          this.nodeTypes.push(nodeType);
+        }
+      });
       // eslint-disable-next-line no-underscore-dangle
-      this.edgeTypes = edges.results.length > 0 ? [edges.results[0]._id.substring(0, edges.results[0]._id.indexOf('/'))] : [];
+      this.edgeTypes = edges.results.length > 0 ? [edges.results[0]._id.split('/')[0]] : [];
 
       // eslint-disable-next-line no-underscore-dangle
       this.nodes = nodes.results.map((node) => node._id);

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -258,7 +258,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import { Edge } from 'multinet';
+import { EdgesSpec } from 'multinet';
 
 import api from '@/api';
 import { KeyValue } from '@/types';
@@ -391,27 +391,34 @@ export default Vue.extend({
   methods: {
     async update() {
       this.loading = true;
-      const attributes = await api.attributes(this.workspace, this.graph, `${this.type}/${this.node}`);
-      const incoming = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
+      const nodeTable = (await api.table(this.workspace, this.type, {})).results;
+      // eslint-disable-next-line no-underscore-dangle
+      const node = nodeTable[nodeTable.map((table) => table._key).indexOf(this.node)];
+      const incoming = (await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
         direction: 'incoming',
         offset: this.offsetIncoming,
         limit: this.pageCount,
-      });
-      const outgoing = await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
+      // eslint-disable-next-line no-underscore-dangle
+      })).results.filter((edge) => edge._to === `${this.type}/${this.node}`);
+      const outgoing = (await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
         direction: 'outgoing',
         offset: this.offsetOutgoing,
         limit: this.pageCount,
-      });
+      // eslint-disable-next-line no-underscore-dangle
+      })).results.filter((edge) => edge._from === `${this.type}/${this.node}`);
 
-      this.attributes = Object.entries(attributes).map(([key, value]) => ({
+      // eslint-disable-next-line no-underscore-dangle
+      this.attributes = Object.entries(node).filter(([key]) => key !== '_rev').map(([key, value]) => ({
         key,
         value,
       }));
 
-      this.incoming = incoming.edges.map((edge: Edge) => ({ id: edge.edge, node: edge.from }));
-      this.outgoing = outgoing.edges.map((edge: Edge) => ({ id: edge.edge, node: edge.to }));
-      this.totalIncoming = incoming.count;
-      this.totalOutgoing = outgoing.count;
+      // eslint-disable-next-line no-underscore-dangle
+      this.incoming = incoming.map((edge: EdgesSpec) => ({ id: edge._id, node: edge._from }));
+      // eslint-disable-next-line no-underscore-dangle
+      this.outgoing = outgoing.map((edge: EdgesSpec) => ({ id: edge._id, node: edge._to }));
+      this.totalIncoming = this.incoming.length;
+      this.totalOutgoing = this.outgoing.length;
 
       this.loading = false;
     },

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -393,7 +393,7 @@ export default Vue.extend({
       this.loading = true;
       const nodeTable = (await api.table(this.workspace, this.type, {})).results;
       // eslint-disable-next-line no-underscore-dangle
-      const node = nodeTable[nodeTable.map((table) => table._key).indexOf(this.node)];
+      const node = nodeTable.find((table) => table._key === this.node);
       const incoming = (await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
         direction: 'incoming',
         offset: this.offsetIncoming,

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -394,13 +394,13 @@ export default Vue.extend({
       const nodeTable = (await api.table(this.workspace, this.type, {})).results;
       // eslint-disable-next-line no-underscore-dangle
       const node = nodeTable.find((table) => table._key === this.node);
-      const incoming = (await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
+      const incoming = (await api.edges(this.workspace, this.graph, {
         direction: 'incoming',
         offset: this.offsetIncoming,
         limit: this.pageCount,
       // eslint-disable-next-line no-underscore-dangle
       })).results.filter((edge) => edge._to === `${this.type}/${this.node}`);
-      const outgoing = (await api.edges(this.workspace, this.graph, `${this.type}/${this.node}`, {
+      const outgoing = (await api.edges(this.workspace, this.graph, {
         direction: 'outgoing',
         offset: this.offsetOutgoing,
         limit: this.pageCount,

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -267,7 +267,7 @@ export default Vue.extend({
           rowKeys.push(rowData);
         });
 
-        headers = Object.keys(rows[0]).filter((d) => d !== '_rev');
+        headers = rows.length > 0 ? Object.keys(rows[0]).filter((d) => d !== '_rev') : [];
       }
 
       this.rowKeys = rowKeys;


### PR DESCRIPTION
This PR changes how the client interacts with the data provided by multinetjs to display information about networks and nodes properly.  It also includes the following changes to adjust to the new backend:
- displaying user's initials
- changing to the appropriate localhost server address
- adjusting how table-network dependencies are calculated to warn users when they delete tables
- checking that tables aren't empty before attempting to display their rows

This PR works in conjunction with changes found in the [new-return-types](https://github.com/multinet-app/multinetjs/tree/new-return-types) branch of multinetjs

Resolves #161