### PR TITLE
Support S3 File Field Upload functionality

### DIFF
--- a/src/components/FileUploadForm.vue
+++ b/src/components/FileUploadForm.vue
@@ -77,7 +77,6 @@ import Vue, { PropType } from 'vue';
 
 import api from '@/api';
 import { FileType } from '@/types';
-import { host } from '@/environment';
 
 export default Vue.extend({
   name: 'FileUploadForm',
@@ -184,7 +183,6 @@ export default Vue.extend({
         await api.uploadNetwork(workspace, fileName, {
           type: selectedType.queryCall as UploadType,
           data: file,
-          url: host,
         }, {
           onUploadProgress: this.handleUploadProgress,
         });

--- a/src/components/FileUploadForm.vue
+++ b/src/components/FileUploadForm.vue
@@ -77,6 +77,7 @@ import Vue, { PropType } from 'vue';
 
 import api from '@/api';
 import { FileType } from '@/types';
+import { host } from '@/environment';
 
 export default Vue.extend({
   name: 'FileUploadForm',
@@ -180,9 +181,10 @@ export default Vue.extend({
       this.uploading = true;
 
       try {
-        await api.uploadTable(workspace, fileName, {
+        await api.uploadNetwork(workspace, fileName, {
           type: selectedType.queryCall as UploadType,
           data: file,
+          url: host,
         }, {
           onUploadProgress: this.handleUploadProgress,
         });

--- a/src/components/GraphDialog.vue
+++ b/src/components/GraphDialog.vue
@@ -27,13 +27,8 @@
           </v-tab>
 
           <v-tab-item>
-            <file-upload-form
-              file-type-selector
-              name-placeholder="Network name"
-              file-input-placeholder="Select network file"
-              create-button-text="Upload"
+            <graph-upload-form
               :workspace="workspace"
-              :types="uploadFiletypes"
               @success="graphDialogSuccess"
             />
           </v-tab-item>
@@ -55,13 +50,13 @@
 import Vue, { PropType } from 'vue';
 
 import GraphCreateForm from '@/components/GraphCreateForm.vue';
-import FileUploadForm from '@/components/FileUploadForm.vue';
+import GraphUploadForm from '@/components/GraphUploadForm.vue';
 
 export default Vue.extend({
   name: 'GraphDialog',
   components: {
     GraphCreateForm,
-    FileUploadForm,
+    GraphUploadForm,
   },
   props: {
     edgeTables: {
@@ -77,26 +72,6 @@ export default Vue.extend({
   data() {
     return {
       graphDialog: false,
-      uploadFiletypes: [
-        {
-          displayName: 'D3 JSON (ext: .json)',
-          hint: 'JSON format compatible with d3-force',
-          queryCall: 'd3_json',
-          extension: ['json'],
-        },
-        {
-          displayName: 'Arbor Nested Tree (ext: .json)',
-          hint: 'JSON-encoded tree format used by the Arbor project',
-          queryCall: 'nested_json',
-          extension: ['json'],
-        },
-        {
-          displayName: 'Newick Tree (ext: .phy, .tree)',
-          hint: 'The Newick Standard for representing trees in computer-readable form',
-          queryCall: 'newick',
-          extension: ['phy', 'tree'],
-        },
-      ],
     };
   },
   computed: {},

--- a/src/components/GraphUploadForm.vue
+++ b/src/components/GraphUploadForm.vue
@@ -21,7 +21,7 @@
           class="pl-2"
         >
           <v-select
-            v-if="types.length"
+            v-if="fileTypes.length"
             id="file-type"
             v-model="selectedType"
             class="file-type"

--- a/src/components/GraphUploadForm.vue
+++ b/src/components/GraphUploadForm.vue
@@ -8,7 +8,7 @@
             clearable
             dense
             :error-messages="fileUploadError"
-            :label="fileInputPlaceholder"
+            label="Select network file"
             outlined
             prepend-icon=""
             prepend-inner-icon="attach_file"
@@ -17,7 +17,6 @@
           />
         </v-flex>
         <v-flex
-          v-if="fileTypeSelector"
           xs6
           class="pl-2"
         >
@@ -28,7 +27,7 @@
             class="file-type"
             dense
             :hint="selectedType ? selectedType.hint : null"
-            :items="types"
+            :items="fileTypes"
             item-text="displayName"
             item-value="displayName"
             label="File type"
@@ -45,7 +44,7 @@
             v-model="fileName"
             dense
             :error-messages="tableCreationError"
-            :label="namePlaceholder"
+            label="Network name"
             outlined
           />
         </v-flex>
@@ -59,9 +58,9 @@
       <v-btn
         id="create-table"
         :disabled="createDisabled"
-        @click="createTable"
+        @click="createNetwork"
       >
-        {{ createButtonText }}
+        Upload
       </v-btn>
     </v-card-actions>
     <v-progress-linear
@@ -72,52 +71,50 @@
 </template>
 
 <script lang="ts">
-import { UploadType, validUploadType } from 'multinet';
-import Vue, { PropType } from 'vue';
+import { GraphUploadType, validGraphUploadType } from 'multinet';
+import Vue from 'vue';
 
 import api from '@/api';
-import { FileType } from '@/types';
+import { GraphFileType } from '@/types';
+
+const fileTypes: GraphFileType[] = [
+  {
+    displayName: 'D3 JSON (ext: .json)',
+    hint: 'JSON format compatible with d3-force',
+    queryCall: 'd3_json',
+    extension: ['json'],
+  },
+  {
+    displayName: 'Arbor Nested Tree (ext: .json)',
+    hint: 'JSON-encoded tree format used by the Arbor project',
+    queryCall: 'nested_json',
+    extension: ['json'],
+  },
+  {
+    displayName: 'Newick Tree (ext: .phy, .tree)',
+    hint: 'The Newick Standard for representing trees in computer-readable form',
+    queryCall: 'newick',
+    extension: ['phy', 'tree'],
+  },
+];
 
 export default Vue.extend({
-  name: 'FileUploadForm',
+  name: 'GraphUploadForm',
 
   props: {
-    fileTypeSelector: {
-      type: Boolean,
-      default: false,
-      required: false,
-    },
-    namePlaceholder: {
-      type: String,
-      default: 'Table name',
-      required: false,
-    },
-    fileInputPlaceholder: {
-      type: String,
-      default: 'Upload file',
-      required: false,
-    },
-    createButtonText: {
-      type: String,
-      default: 'Create',
-      required: false,
-    },
     workspace: {
       type: String,
-      required: true,
-    },
-    types: {
-      type: Array as PropType<FileType[]>,
       required: true,
     },
   },
 
   data() {
     return {
+      fileTypes,
       tableCreationError: null as string | null,
       fileUploadError: null as string | null,
       fileName: null as string | null,
-      selectedType: null as FileType | null,
+      selectedType: null as GraphFileType | null,
       file: null as File | null,
       uploading: false,
       uploadProgress: null as number | null,
@@ -161,7 +158,7 @@ export default Vue.extend({
       }
     },
 
-    async createTable() {
+    async createNetwork() {
       const {
         file,
         workspace,
@@ -181,10 +178,8 @@ export default Vue.extend({
 
       try {
         await api.uploadNetwork(workspace, fileName, {
-          type: selectedType.queryCall as UploadType,
+          type: selectedType.queryCall as GraphUploadType,
           data: file,
-        }, {
-          onUploadProgress: this.handleUploadProgress,
         });
 
         this.tableCreationError = null;
@@ -204,7 +199,7 @@ export default Vue.extend({
       }
     },
 
-    fileInfo(file: File): [string, FileType] | null {
+    fileInfo(file: File): [string, GraphFileType] | null {
       if (!file) {
         return null;
       }
@@ -212,7 +207,7 @@ export default Vue.extend({
       const [fileName, ...extensions] = file.name.split('.');
       const extension = extensions[extensions.length - 1];
 
-      const found = this.types.find((type) => type.extension.includes(extension) && validUploadType(type.queryCall));
+      const found = this.fileTypes.find((type) => type.extension.includes(extension) && validGraphUploadType(type.queryCall));
 
       return found === undefined ? null : [fileName, found];
     },

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -218,7 +218,12 @@ export default defineComponent({
       }));
     });
 
-    const edgeTable = computed(() => Object.prototype.hasOwnProperty.call(sampleRows.value[0], '_from') && Object.prototype.hasOwnProperty.call(sampleRows.value[0], '_to'));
+    const edgeTable = computed(() => {
+      const sample = sampleRows.value[0] || {};
+      const hasFrom = Object.prototype.hasOwnProperty.call(sample, '_from');
+      const hasTo = Object.prototype.hasOwnProperty.call(sample, '_to');
+      return hasFrom && hasTo;
+    });
 
     // Type recommendation
     const columnType: Ref<{[key: string]: CSVColumnType}> = ref({});

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -179,7 +179,6 @@ import {
 import api from '@/api';
 import { FileType, CSVColumnType } from '@/types';
 import { validFileType, fileName as getFileName, analyzeCSV } from '@/utils/files';
-import { host } from '@/environment';
 
 const defaultKeyField = '_key';
 const multinetTypes: readonly CSVColumnType[] = ['label', 'boolean', 'category', 'number', 'date'];
@@ -305,7 +304,6 @@ export default defineComponent({
           key: keyField.value,
           overwrite: overwrite.value,
           columnTypes: columnType.value,
-          url: host,
         }, {
           onUploadProgress: handleUploadProgress,
         });

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -179,6 +179,7 @@ import {
 import api from '@/api';
 import { FileType, CSVColumnType } from '@/types';
 import { validFileType, fileName as getFileName, analyzeCSV } from '@/utils/files';
+import { host } from '@/environment';
 
 const defaultKeyField = '_key';
 const multinetTypes: readonly CSVColumnType[] = ['label', 'boolean', 'category', 'number', 'date'];
@@ -298,6 +299,7 @@ export default defineComponent({
           key: keyField.value,
           overwrite: overwrite.value,
           columnTypes: columnType.value,
+          url: host,
         }, {
           onUploadProgress: handleUploadProgress,
         });

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -219,6 +219,11 @@ export default defineComponent({
       }));
     });
 
+    const edgeTable = computed(() => {
+      const keys = Object.keys(sampleRows.value[0] || {});
+      return keys.includes('_from') && keys.includes('_to');
+    });
+
     // Type recommendation
     const columnType: Ref<{[key: string]: CSVColumnType}> = ref({});
 
@@ -296,6 +301,7 @@ export default defineComponent({
         await api.uploadTable(workspace, fileName.value, {
           type: 'csv',
           data: selectedFile.value,
+          edgeTable: edgeTable.value,
           key: keyField.value,
           overwrite: overwrite.value,
           columnTypes: columnType.value,

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -67,7 +67,8 @@
                     />
                   </v-flex>
                 </v-layout>
-                <v-row no-gutters>
+                <!-- TODO: Fix after https://github.com/multinet-app/multinetjs/issues/46 -->
+                <!-- <v-row no-gutters>
                   <v-col cols="4">
                     <v-text-field
                       v-model="keyField"
@@ -87,7 +88,7 @@
                       outlined
                     />
                   </v-col>
-                </v-row>
+                </v-row> -->
               </v-card-text>
 
               <v-divider />
@@ -177,12 +178,12 @@ import {
 } from '@vue/composition-api';
 
 import api from '@/api';
-import { FileType, CSVColumnType } from '@/types';
+import { TableFileType, CSVColumnType } from '@/types';
 import { validFileType, fileName as getFileName, analyzeCSV } from '@/utils/files';
 
 const defaultKeyField = '_key';
 const multinetTypes: readonly CSVColumnType[] = ['label', 'boolean', 'category', 'number', 'date'];
-const fileTypes: readonly FileType[] = [
+const fileTypes: readonly TableFileType[] = [
   {
     extension: ['csv'],
     queryCall: 'csv',
@@ -266,9 +267,9 @@ export default defineComponent({
     // Upload state
     const uploading = ref(false);
     const uploadProgress = ref<number | null>(null);
-    function handleUploadProgress(evt: { loaded: number; total: number; [key: string]: unknown }) {
-      uploadProgress.value = (evt.loaded / evt.total) * 100;
-    }
+    // function handleUploadProgress(evt: { loaded: number; total: number; [key: string]: unknown }) {
+    //   uploadProgress.value = (evt.loaded / evt.total) * 100;
+    // }
 
     // Reset component
     function resetAllFields() {
@@ -303,11 +304,7 @@ export default defineComponent({
           type: 'csv',
           data: selectedFile.value,
           edgeTable: edgeTable.value,
-          key: keyField.value,
-          overwrite: overwrite.value,
           columnTypes: columnType.value,
-        }, {
-          onUploadProgress: handleUploadProgress,
         });
 
         tableCreationError.value = null;

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -218,10 +218,7 @@ export default defineComponent({
       }));
     });
 
-    const edgeTable = computed(() => {
-      const keys = Object.keys(sampleRows.value[0] || {});
-      return keys.includes('_from') && keys.includes('_to');
-    });
+    const edgeTable = computed(() => Object.prototype.hasOwnProperty.call(sampleRows.value[0], '_from') && Object.prototype.hasOwnProperty.call(sampleRows.value[0], '_to'));
 
     // Type recommendation
     const columnType: Ref<{[key: string]: CSVColumnType}> = ref({});

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -301,7 +301,6 @@ export default defineComponent({
 
       try {
         await api.uploadTable(workspace, fileName.value, {
-          type: 'csv',
           data: selectedFile.value,
           edgeTable: edgeTable.value,
           columnTypes: columnType.value,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { UploadType } from 'multinet';
+import { UploadType, TableUploadType, GraphUploadType } from 'multinet';
 
 export type CSVColumnType = 'label' | 'boolean' | 'category' | 'number' | 'date';
 
@@ -28,6 +28,13 @@ export interface FileType {
   hint: string;
   extension: string[];
   queryCall: UploadType;
+}
+
+export interface TableFileType extends FileType{
+  queryCall: TableUploadType;
+}
+export interface GraphFileType extends FileType{
+  queryCall: GraphUploadType;
 }
 
 export interface FileTypeTable {


### PR DESCRIPTION
Update the client to pass additional information to multinetjs to allow for table and network uploads using the S3 File Field client.

This PR works in conjunction with the s3ff branch of [multinetjs](https://github.com/multinet-app/multinetjs/tree/s3ff)

Should be merged after #178.  Commits pertinent to this PR are 9e1d1df, 86dd4fc and fcaec43, which make changes to FileUploadForm.vue and TableDialog.vue (all other commits are for changes addressed in #178).
**Edit: Now that #178 is merged, all commits associated with this PR are relevant.**