### PR TITLE
Ensure compatability with girder4 permission endpoints

### DIFF
--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -208,7 +208,7 @@ export default Vue.extend({
         });
 
         const prelimNodes = nodes.results.map((node) => tableName(node));
-        const nodeTables = [];
+        const nodeTables: string[] = [];
         prelimNodes.forEach((table) => {
           if (!nodeTables.includes(table)) {
             nodeTables.push(table);

--- a/src/components/PermissionsDialog.vue
+++ b/src/components/PermissionsDialog.vue
@@ -371,8 +371,7 @@ export default Vue.extend({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async setPermissions(this: any) {
       try {
-        const requestData: WorkspacePermissionsSpec = this.mutablePermissions;
-        await api.setWorkspacePermissions(this.workspace, requestData);
+        await api.setWorkspacePermissions(this.workspace, this.mutablePermissions);
         this.permDialog = false;
       } catch (error) {
         console.log(error);

--- a/src/components/PermissionsDialog.vue
+++ b/src/components/PermissionsDialog.vue
@@ -201,7 +201,7 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import api from '@/api';
-import { WorkspacePermissionsSpec, WorkspacePermissionRequestSpec, UserSpec } from 'multinet';
+import { WorkspacePermissionsSpec, UserSpec } from 'multinet';
 import { cloneDeep, debounce } from 'lodash';
 
 import store from '@/store';
@@ -209,7 +209,6 @@ import {
   Role,
   SingularRole,
   canChangeWorkspacePermissions,
-  buildPermissionsRequestData,
 } from '@/utils/permissions';
 
 export interface UserPermissionSpec {
@@ -372,7 +371,7 @@ export default Vue.extend({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async setPermissions(this: any) {
       try {
-        const requestData: WorkspacePermissionRequestSpec = buildPermissionsRequestData(this.mutablePermissions);
+        const requestData: WorkspacePermissionsSpec = this.mutablePermissions;
         await api.setWorkspacePermissions(this.workspace, requestData);
         this.permDialog = false;
       } catch (error) {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,4 +1,4 @@
-import { WorkspacePermissionsSpec, WorkspacePermissionRequestSpec, UserSpec } from 'multinet';
+import { WorkspacePermissionsSpec, UserSpec } from 'multinet';
 
 export type Role = 'owner' | 'maintainers' | 'writers' | 'readers';
 export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader';
@@ -15,20 +15,4 @@ export function canChangeWorkspacePermissions(userInfo: UserSpec | null, permiss
   }
 
   return false;
-}
-
-export function buildPermissionsRequestData(permissions: WorkspacePermissionsSpec): WorkspacePermissionRequestSpec {
-  const owner = ({ username: permissions.owner.username });
-  const maintainers = permissions.maintainers.map((user) => ({ username: user.username }));
-  const writers = permissions.writers.map((user) => ({ username: user.username }));
-  const readers = permissions.readers.map((user) => ({ username: user.username }));
-
-  const permissionsRequestData: WorkspacePermissionRequestSpec = {
-    owner,
-    maintainers,
-    writers,
-    readers,
-    public: permissions.public,
-  };
-  return permissionsRequestData;
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,4 +1,4 @@
-import { WorkspacePermissionsSpec, UserSpec } from 'multinet';
+import { WorkspacePermissionsSpec, WorkspacePermissionRequestSpec, UserSpec } from 'multinet';
 
 export type Role = 'owner' | 'maintainers' | 'writers' | 'readers';
 export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader';
@@ -6,13 +6,29 @@ export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader';
 export function canChangeWorkspacePermissions(userInfo: UserSpec | null, permissions: WorkspacePermissionsSpec | null): boolean {
   if (!userInfo || !permissions) { return false; }
 
-  const userSub = userInfo.sub;
-  const ownerSub = permissions.owner.sub;
-  const maintainerSubs = permissions.maintainers.map((user) => user.sub);
+  const userId = userInfo.id;
+  const ownerId = permissions.owner.id;
+  const maintainerIds = permissions.maintainers.map((user) => user.id);
 
-  if (maintainerSubs.includes(userSub) || userSub === ownerSub) {
+  if (maintainerIds.includes(userId) || userId === ownerId) {
     return true;
   }
 
   return false;
+}
+
+export function buildPermissionsRequestData(permissions: WorkspacePermissionsSpec): WorkspacePermissionRequestSpec {
+  const owner = ({ username: permissions.owner.username });
+  const maintainers = permissions.maintainers.map((user) => ({ username: user.username }));
+  const writers = permissions.writers.map((user) => ({ username: user.username }));
+  const readers = permissions.readers.map((user) => ({ username: user.username }));
+
+  const permissionsRequestData: WorkspacePermissionRequestSpec = {
+    owner,
+    maintainers,
+    writers,
+    readers,
+    public: permissions.public,
+  };
+  return permissionsRequestData;
 }

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -408,10 +408,12 @@ export default Vue.extend({
       })).results.filter((edge) => edge._from === `${this.type}/${this.node}`);
 
       // eslint-disable-next-line no-underscore-dangle
-      this.attributes = Object.entries(node).filter(([key]) => key !== '_rev').map(([key, value]) => ({
-        key,
-        value,
-      }));
+      if (node) {
+        this.attributes = Object.entries(node).filter(([key]) => key !== '_rev').map(([key, value]) => ({
+          key,
+          value,
+        }));
+      }
 
       // eslint-disable-next-line no-underscore-dangle
       this.incoming = incoming.map((edge: EdgesSpec) => ({ id: edge._id, node: edge._from }));


### PR DESCRIPTION
Closes #177 

This pull request updates the `multinet-client` to be compatible with the new Girder4 back end API. It is dependent on changes 
present in the [girder4-permissions branch](https://github.com/multinet-app/multinetjs/tree/girder4-permissions) of the `multinetjs` repository. 

Changes include:

1. Updating property access on objects of type `UserSpec` to conform with the Django `User` model
2. Cleaning up some linting issues by adding typing and  a null check