### PR TITLE
Always run CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-    branches:
-      - master
-
-  push:
-    branches:
-      - master
-
+on: [push, pull_request]
 jobs:
   build-and-test:
     name: Build and test on Ubuntu - Node 10


### PR DESCRIPTION
Previously, CI would only run on PRs and pushes to `master`.