### PR TITLE
Refactor client to work with new workspace renaming endpoint

### DIFF
--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -258,7 +258,7 @@ export default Vue.extend({
 
       if (this.localWorkspace !== null) {
         try {
-          const { data } = await api.renameWorkspace(this.workspace, this.localWorkspace);
+          const data = (await api.renameWorkspace(this.workspace, this.localWorkspace)).name;
           this.$router.push(`/workspaces/${data}`);
           this.editing = false;
           this.requestError = null;

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -258,8 +258,8 @@ export default Vue.extend({
 
       if (this.localWorkspace !== null) {
         try {
-          const data = (await api.renameWorkspace(this.workspace, this.localWorkspace)).name;
-          this.$router.push(`/workspaces/${data}`);
+          const { name } = await api.renameWorkspace(this.workspace, this.localWorkspace);
+          this.$router.push(`/workspaces/${name}`);
           this.editing = false;
           this.requestError = null;
 


### PR DESCRIPTION
Removes the use of a destructuring assignment for the data variable and extracts the new name of the workspace to account for the new Workspace return type of renameWorkspace() and support the use of the new workspace renaming endpoint.

Works in conjunction with the rename-workspace branches of [multinetjs](https://github.com/multinet-app/multinetjs/tree/rename-workspace) and [multinet-api](https://github.com/multinet-app/multinet-api/tree/rename-workspace).