### PR TITLE
Replace all use of 'graph(s)' with 'network(s)' for consistency

### DIFF
--- a/src/components/DeleteNetworkDialog.vue
+++ b/src/components/DeleteNetworkDialog.vue
@@ -131,7 +131,7 @@ export default Vue.extend({
         workspace,
       } = this;
 
-      await Promise.all(selection.map((graph) => api.deleteGraph(workspace, graph)));
+      await Promise.all(selection.map((network) => api.deleteNetwork(workspace, network)));
 
       this.$emit('closed', [...selection]);
       this.dialog = false;

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -28,7 +28,7 @@
       </v-tooltip>
     </template>
 
-    <v-card v-if="!dependentGraphs">
+    <v-card v-if="!dependentNetworks">
       <v-card-title
         class="headline pb-0 pt-3 px-5"
         primary-title
@@ -83,10 +83,10 @@
         The following networks are using these tables:
         <ul>
           <li
-            v-for="(graph, index) in using"
+            v-for="(network, index) in using"
             :key="index"
           >
-            {{ graph.graph }} ({{ graph.tables.join(', ') }})
+            {{ network.network }} ({{ network.tables.join(', ') }})
           </li>
         </ul>
       </v-card-text>
@@ -136,7 +136,7 @@ export default Vue.extend({
       dialog: false,
       confirmationPhrase: '',
       confirmation: '',
-      using: [] as Array<{graph: string; tables: string[]}>,
+      using: [] as Array<{network: string; tables: string[]}>,
     };
   },
 
@@ -152,7 +152,7 @@ export default Vue.extend({
       return this.selection.length > 0;
     },
 
-    dependentGraphs(): boolean {
+    dependentNetworks(): boolean {
       return this.using.length > 0;
     },
   },
@@ -161,7 +161,7 @@ export default Vue.extend({
     async dialog() {
       if (this.dialog) {
         this.using = [];
-        const using = await this.findDependentGraphs();
+        const using = await this.findDependentNetworks();
         if (using.length > 0) {
           this.using = using;
         } else {
@@ -188,7 +188,7 @@ export default Vue.extend({
       this.confirmationPhrase = randomPhrase();
     },
 
-    async findDependentGraphs() {
+    async findDependentNetworks() {
       const {
         selection,
         workspace,
@@ -199,11 +199,11 @@ export default Vue.extend({
         return tableRow._id.split('/')[0];
       }
 
-      const graphNames = (await api.graphs(workspace)).results.map((graph) => graph.name);
-      const using = [] as Array<{graph: string; tables: string[]}>;
-      graphNames.forEach(async (graph) => {
-        const nodes = await api.nodes(workspace, graph, {});
-        const edges = await api.edges(workspace, graph, {
+      const networkNames = (await api.networks(workspace)).results.map((network) => network.name);
+      const using = [] as Array<{network: string; tables: string[]}>;
+      networkNames.forEach(async (network) => {
+        const nodes = await api.nodes(workspace, network, {});
+        const edges = await api.edges(workspace, network, {
           direction: 'all',
         });
 
@@ -224,7 +224,7 @@ export default Vue.extend({
 
         if (tables.length > 0) {
           using.push({
-            graph,
+            network,
             tables,
           });
         }

--- a/src/components/DownloadDialog.vue
+++ b/src/components/DownloadDialog.vue
@@ -137,7 +137,7 @@ export default Vue.extend({
           return api.downloadTable.bind(api);
         case 'network':
         default:
-          return api.downloadGraph.bind(api);
+          return api.downloadNetwork.bind(api);
       }
     },
   },

--- a/src/components/NetworkCreateForm.vue
+++ b/src/components/NetworkCreateForm.vue
@@ -4,7 +4,7 @@
       <v-layout wrap>
         <v-flex>
           <v-select
-            v-model="graphEdgeTable"
+            v-model="networkEdgeTable"
             dense
             :items="edgeTables"
             label="Choose edge table"
@@ -16,9 +16,9 @@
       <v-layout wrap>
         <v-flex>
           <v-text-field
-            v-model="newGraph"
+            v-model="newNetwork"
             dense
-            :error-messages="graphCreationErrors"
+            :error-messages="networkCreationErrors"
             label="Network name"
             outlined
           />
@@ -32,8 +32,8 @@
       <v-spacer />
       <v-btn
         depressed
-        :disabled="graphCreateDisabled"
-        @click="createGraph"
+        :disabled="networkCreateDisabled"
+        @click="createNetwork"
       >
         create network
       </v-btn>
@@ -47,7 +47,7 @@ import Vue, { PropType } from 'vue';
 import api from '@/api';
 
 export default Vue.extend({
-  name: 'GraphCreateForm',
+  name: 'NetworkCreateForm',
   props: {
     edgeTables: {
       type: Array as PropType<string[]>,
@@ -61,33 +61,33 @@ export default Vue.extend({
   },
   data() {
     return {
-      graphCreationErrors: [] as string[],
-      graphEdgeTable: null as string | null,
-      newGraph: '',
+      networkCreationErrors: [] as string[],
+      networkEdgeTable: null as string | null,
+      newNetwork: '',
     };
   },
   computed: {
-    graphCreateDisabled(): boolean {
-      return !this.graphEdgeTable || !this.newGraph;
+    networkCreateDisabled(): boolean {
+      return !this.networkEdgeTable || !this.newNetwork;
     },
   },
   methods: {
-    async createGraph() {
-      const { workspace, newGraph } = this;
+    async createNetwork() {
+      const { workspace, newNetwork } = this;
 
-      if (this.graphEdgeTable === null) {
-        throw new Error('this.graphEdgeTable must not be null');
+      if (this.networkEdgeTable === null) {
+        throw new Error('this.networkEdgeTable must not be null');
       }
 
       try {
-        await api.createGraph(workspace, newGraph, {
-          edgeTable: this.graphEdgeTable,
+        await api.createNetwork(workspace, newNetwork, {
+          edgeTable: this.networkEdgeTable,
         });
-        this.graphCreationErrors = [];
+        this.networkCreationErrors = [];
         this.$emit('success');
       } catch (error) {
-        const message = `Network "${this.newGraph}" already exists.`;
-        this.graphCreationErrors = [message];
+        const message = `Network "${this.newNetwork}" already exists.`;
+        this.networkCreationErrors = [message];
       }
     },
   },

--- a/src/components/NetworkDialog.vue
+++ b/src/components/NetworkDialog.vue
@@ -1,11 +1,11 @@
 <template>
   <v-dialog
-    v-model="graphDialog"
+    v-model="networkDialog"
     width="700"
   >
     <template v-slot:activator="{ on }">
       <v-btn
-        id="add-graph"
+        id="add-network"
         color="blue darken-2"
         icon
         medium
@@ -27,17 +27,17 @@
           </v-tab>
 
           <v-tab-item>
-            <graph-upload-form
+            <network-upload-form
               :workspace="workspace"
-              @success="graphDialogSuccess"
+              @success="networkDialogSuccess"
             />
           </v-tab-item>
 
           <v-tab-item>
-            <graph-create-form
+            <network-create-form
               :edge-tables="edgeTables"
               :workspace="workspace"
-              @success="graphDialogSuccess"
+              @success="networkDialogSuccess"
             />
           </v-tab-item>
         </v-tabs>
@@ -49,14 +49,14 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 
-import GraphCreateForm from '@/components/GraphCreateForm.vue';
-import GraphUploadForm from '@/components/GraphUploadForm.vue';
+import NetworkCreateForm from '@/components/NetworkCreateForm.vue';
+import NetworkUploadForm from '@/components/NetworkUploadForm.vue';
 
 export default Vue.extend({
-  name: 'GraphDialog',
+  name: 'NetworkDialog',
   components: {
-    GraphCreateForm,
-    GraphUploadForm,
+    NetworkCreateForm,
+    NetworkUploadForm,
   },
   props: {
     edgeTables: {
@@ -71,13 +71,13 @@ export default Vue.extend({
   },
   data() {
     return {
-      graphDialog: false,
+      networkDialog: false,
     };
   },
   computed: {},
   methods: {
-    graphDialogSuccess() {
-      this.graphDialog = false;
+    networkDialogSuccess() {
+      this.networkDialog = false;
       this.$emit('success');
     },
   },

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -16,11 +16,11 @@
           ref="downloader"
           :selection="selection"
           :workspace="workspace"
-          download-type="graph"
+          download-type="network"
           @downloaded="cleanup"
         />
 
-        <delete-graph-dialog
+        <delete-network-dialog
           ref="deleter"
           :selection="selection"
           :workspace="workspace"
@@ -28,7 +28,7 @@
         />
       </div>
 
-      <graph-dialog
+      <network-dialog
         :workspace="workspace"
         :node-tables="nodeTables"
         :edge-tables="edgeTables"
@@ -62,7 +62,7 @@
             slot-scope="{ hover }"
             active-class="grey lighten-4"
             ripple
-            :to="`/workspaces/${workspace}/graph/${item}`"
+            :to="`/workspaces/${workspace}/network/${item}`"
           >
             <v-list-item-action @click.prevent>
               <v-icon
@@ -120,18 +120,18 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import DeleteGraphDialog from '@/components/DeleteGraphDialog.vue';
-import GraphDialog from '@/components/GraphDialog.vue';
+import DeleteNetworkDialog from '@/components/DeleteNetworkDialog.vue';
+import NetworkDialog from '@/components/NetworkDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
 
 export default Vue.extend({
-  name: 'GraphPanel',
+  name: 'NetworkPanel',
 
   components: {
-    DeleteGraphDialog,
-    GraphDialog,
+    DeleteNetworkDialog,
+    NetworkDialog,
     DownloadDialog,
   },
 

--- a/src/components/NetworkUploadForm.vue
+++ b/src/components/NetworkUploadForm.vue
@@ -71,13 +71,13 @@
 </template>
 
 <script lang="ts">
-import { GraphUploadType, validGraphUploadType } from 'multinet';
+import { NetworkUploadType, validNetworkUploadType } from 'multinet';
 import Vue from 'vue';
 
 import api from '@/api';
-import { GraphFileType } from '@/types';
+import { NetworkFileType } from '@/types';
 
-const fileTypes: GraphFileType[] = [
+const fileTypes: NetworkFileType[] = [
   {
     displayName: 'D3 JSON (ext: .json)',
     hint: 'JSON format compatible with d3-force',
@@ -99,7 +99,7 @@ const fileTypes: GraphFileType[] = [
 ];
 
 export default Vue.extend({
-  name: 'GraphUploadForm',
+  name: 'NetworkUploadForm',
 
   props: {
     workspace: {
@@ -114,7 +114,7 @@ export default Vue.extend({
       tableCreationError: null as string | null,
       fileUploadError: null as string | null,
       fileName: null as string | null,
-      selectedType: null as GraphFileType | null,
+      selectedType: null as NetworkFileType | null,
       file: null as File | null,
       uploading: false,
       uploadProgress: null as number | null,
@@ -178,7 +178,7 @@ export default Vue.extend({
 
       try {
         await api.uploadNetwork(workspace, fileName, {
-          type: selectedType.queryCall as GraphUploadType,
+          type: selectedType.queryCall as NetworkUploadType,
           data: file,
         });
 
@@ -199,7 +199,7 @@ export default Vue.extend({
       }
     },
 
-    fileInfo(file: File): [string, GraphFileType] | null {
+    fileInfo(file: File): [string, NetworkFileType] | null {
       if (!file) {
         return null;
       }
@@ -207,7 +207,7 @@ export default Vue.extend({
       const [fileName, ...extensions] = file.name.split('.');
       const extension = extensions[extensions.length - 1];
 
-      const found = this.fileTypes.find((type) => type.extension.includes(extension) && validGraphUploadType(type.queryCall));
+      const found = this.fileTypes.find((type) => type.extension.includes(extension) && validNetworkUploadType(type.queryCall));
 
       return found === undefined ? null : [fileName, found];
     },

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,7 +4,7 @@ import VueRouter from 'vue-router';
 import FrontPage from '@/views/FrontPage.vue';
 import WorkspaceDetail from '@/views/WorkspaceDetail.vue';
 import TableDetail from '@/views/TableDetail.vue';
-import GraphDetail from '@/views/GraphDetail.vue';
+import NetworkDetail from '@/views/NetworkDetail.vue';
 import NodeDetail from '@/views/NodeDetail.vue';
 import AQLWizard from '@/views/AQLWizard.vue';
 
@@ -35,13 +35,13 @@ const routes = [
     props: true,
   },
   {
-    path: '/workspaces/:workspace/graph/:graph',
-    name: 'graphDetail',
-    component: GraphDetail,
+    path: '/workspaces/:workspace/network/:network',
+    name: 'networkDetail',
+    component: NetworkDetail,
     props: true,
   },
   {
-    path: '/workspaces/:workspace/graph/:graph/node/:type/:node',
+    path: '/workspaces/:workspace/network/:network/node/:type/:node',
     name: 'nodeDetail',
     component: NodeDetail,
     props: true,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,7 +12,7 @@ export interface WorkspaceState {
   name: string;
   nodeTables: string[];
   edgeTables: string[];
-  graphs: string[];
+  networks: string[];
 }
 
 export interface State {
@@ -48,9 +48,9 @@ const {
       return [];
     },
 
-    graphs(state: State) {
-      if (state.currentWorkspace !== null && state.currentWorkspace.graphs) {
-        return state.currentWorkspace.graphs;
+    networks(state: State) {
+      if (state.currentWorkspace !== null && state.currentWorkspace.networks) {
+        return state.currentWorkspace.networks;
       }
       return [];
     },
@@ -83,7 +83,7 @@ const {
       const { commit } = rootActionContext(context);
       commit.unsetCurrentWorkspace();
 
-      const graphs = await api.graphs(workspace);
+      const networks = await api.networks(workspace);
       const tables = (await api.tables(workspace)).results;
       const nodeTables = tables.filter((table) => table.edge === false);
       const edgeTables = tables.filter((table) => table.edge === true);
@@ -92,7 +92,7 @@ const {
         name: workspace,
         nodeTables: nodeTables.map((table) => table.name),
         edgeTables: edgeTables.map((table) => table.name),
-        graphs: graphs.results.map((graph) => graph.name),
+        networks: networks.results.map((network) => network.name),
       });
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { UploadType, TableUploadType, GraphUploadType } from 'multinet';
+import { UploadType, TableUploadType, NetworkUploadType } from 'multinet';
 
 export type CSVColumnType = 'label' | 'boolean' | 'category' | 'number' | 'date';
 
@@ -33,8 +33,8 @@ export interface FileType {
 export interface TableFileType extends FileType{
   queryCall: TableUploadType;
 }
-export interface GraphFileType extends FileType{
-  queryCall: GraphUploadType;
+export interface NetworkFileType extends FileType{
+  queryCall: NetworkUploadType;
 }
 
 export interface FileTypeTable {

--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -11,7 +11,7 @@
         </h2>
         <v-divider />
         <v-card
-          v-for="{ title, data, graph } in workspaceInfo"
+          v-for="{ title, data, network } in workspaceInfo"
           :key="title"
           flat
         >
@@ -30,11 +30,11 @@
                 :key="name"
                 dense
                 style="min-height: 30px;"
-                :to="detailLink(name, graph)"
+                :to="detailLink(name, network)"
               >
                 <v-list-item-icon class="ma-0 mt-1">
                   <v-icon small>
-                    {{ graph ? "timeline" : "table_chart" }}
+                    {{ network ? "timeline" : "table_chart" }}
                   </v-icon>
                 </v-list-item-icon>
                 {{ name }}
@@ -157,12 +157,12 @@ export default {
   computed: {
     nodeTables: () => store.getters.nodeTables,
     edgeTables: () => store.getters.edgeTables,
-    graphs: () => store.getters.graphs,
+    networks: () => store.getters.networks,
     workspaceInfo() {
       return [
         { title: 'Node Tables', data: this.nodeTables },
         { title: 'Edge Tables', data: this.edgeTables },
-        { title: 'Graphs', data: this.graphs, graph: true },
+        { title: 'Networks', data: this.networks, network: true },
       ];
     },
   },
@@ -197,11 +197,11 @@ export default {
   },
   methods: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    detailLink(this: any, name: string, graph: boolean) {
+    detailLink(this: any, name: string, network: boolean) {
       const { workspace } = this;
-      const route = graph ? 'graphDetail' : 'tableDetail';
+      const route = network ? 'networkDetail' : 'tableDetail';
 
-      return { name: route, params: { workspace, table: name, graph: name } };
+      return { name: route, params: { workspace, table: name, network: name } };
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async createTable(this: any) {

--- a/src/views/NetworkDetail.vue
+++ b/src/views/NetworkDetail.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container
-    class="graph-container"
+    class="network-container"
     fill-height
     fluid
     pa-0
@@ -34,7 +34,7 @@
             class="mr-3"
             color="grey lighten-1"
           >timeline</v-icon>
-          {{ graph }}
+          {{ network }}
         </span>
       </v-toolbar-title>
 
@@ -53,7 +53,7 @@
         fluid
         pa-0
       >
-        <div :class="graphVisClasses">
+        <div :class="networkVisClasses">
           <v-list>
             <v-list-item>
               <v-list-item-title>
@@ -93,7 +93,7 @@
                 v-for="app in apps"
                 :key="app.name"
                 class="pl-2"
-                :href="`${app.url}/?workspace=${workspace}&graph=${graph}`"
+                :href="`${app.url}/?workspace=${workspace}&network=${network}`"
                 target="_blank"
               >
                 <v-list-item-avatar class="mr-3">
@@ -292,7 +292,7 @@
                   <v-list-item
                     v-for="node in nodes"
                     :key="node"
-                    :to="`/workspaces/${workspace}/graph/${graph}/node/${node}`"
+                    :to="`/workspaces/${workspace}/network/${network}/node/${node}`"
                   >
                     <v-list-item-title>
                       {{ node }}
@@ -332,10 +332,10 @@ import api from '@/api';
 import { App } from '@/types';
 
 export default Vue.extend({
-  name: 'GraphDetail',
+  name: 'NetworkDetail',
   filters: {
     appendArgs(url: string) {
-      return `${url}/?workspace=${this.workspace}&graph=${this.graph}`;
+      return `${url}/?workspace=${this.workspace}&graph=${this.network}`;
     },
   },
   props: {
@@ -343,7 +343,7 @@ export default Vue.extend({
       type: String as PropType<string>,
       required: true,
     },
-    graph: {
+    network: {
       type: String as PropType<string>,
       required: true,
     },
@@ -389,12 +389,12 @@ export default Vue.extend({
 
       return `d-flex flex-row node-cols${panelOpen ? '' : ' node-cols-closed'}`;
     },
-    graphVisClasses(): string {
+    networkVisClasses(): string {
       const {
         panelOpen,
       } = this;
 
-      return `graph-vis${panelOpen ? '' : ' graph-vis-closed'}`;
+      return `network-vis${panelOpen ? '' : ' network-vis-closed'}`;
     },
     drawerIcon(): string {
       return this.panelOpen ? 'expand_more' : 'expand_less';
@@ -410,7 +410,7 @@ export default Vue.extend({
     workspace() {
       this.update();
     },
-    graph() {
+    network() {
       this.update();
     },
   },
@@ -427,17 +427,17 @@ export default Vue.extend({
         return tableRow._id.split('/')[0];
       }
       this.loading = true;
-      const graph = await api.graph(this.workspace, this.graph);
-      const nodes = await api.nodes(this.workspace, this.graph, {
+      const network = await api.network(this.workspace, this.network);
+      const nodes = await api.nodes(this.workspace, this.network, {
         offset: this.offset,
         limit: this.limit,
       });
-      const edges = await api.edges(this.workspace, this.graph, {
+      const edges = await api.edges(this.workspace, this.network, {
         offset: this.offset,
         limit: this.limit,
       });
-      this.totalNodes = graph.node_count;
-      this.totalEdges = graph.edge_count;
+      this.totalNodes = network.node_count;
+      this.totalEdges = network.edge_count;
 
       const prelimNodes = nodes.results.map((node) => tableName(node));
       prelimNodes.forEach((nodeType) => {
@@ -471,13 +471,13 @@ ul {
   text-align: left;
 }
 
-.graph-vis {
+.network-vis {
   height: calc(100vh - 314px);
   position: relative;
   z-index: 1;
 }
 
-.graph-vis-closed {
+.network-vis-closed {
   height: calc(100vh - 75px);
 }
 

--- a/src/views/NetworkDetail.vue
+++ b/src/views/NetworkDetail.vue
@@ -333,11 +333,6 @@ import { App } from '@/types';
 
 export default Vue.extend({
   name: 'NetworkDetail',
-  filters: {
-    appendArgs(url: string) {
-      return `${url}/?workspace=${this.workspace}&graph=${this.network}`;
-    },
-  },
   props: {
     workspace: {
       type: String as PropType<string>,

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -34,11 +34,11 @@
             </v-icon>
             <router-link
               :to="{
-                name: 'graphDetail',
-                params: { graph }
+                name: 'networkDetail',
+                params: { network }
               }"
             >
-              {{ graph }}
+              {{ network }}
             </router-link>
             <v-icon
               class="mx-4"
@@ -175,7 +175,7 @@
                   <v-list-item
                     v-for="(edge, index) in incoming"
                     :key="index"
-                    :to="`/workspaces/${workspace}/graph/${graph}/node/${edge.node}`"
+                    :to="`/workspaces/${workspace}/network/${network}/node/${edge.node}`"
                   >
                     <v-list-item-content>
                       {{ edge.node }}
@@ -240,7 +240,7 @@
                   <v-list-item
                     v-for="(edge, index) in outgoing"
                     :key="index"
-                    :to="`/workspaces/${workspace}/graph/${graph}/node/${edge.node}`"
+                    :to="`/workspaces/${workspace}/network/${network}/node/${edge.node}`"
                   >
                     <v-list-item-content>
                       {{ edge.node }}
@@ -284,7 +284,7 @@ export default Vue.extend({
       required: true,
     },
 
-    graph: {
+    network: {
       type: String as PropType<string>,
       required: true,
     },
@@ -366,7 +366,7 @@ export default Vue.extend({
     workspace() {
       this.update();
     },
-    graph() {
+    network() {
       this.update();
     },
     type() {
@@ -394,13 +394,13 @@ export default Vue.extend({
       const nodeTable = (await api.table(this.workspace, this.type, {})).results;
       // eslint-disable-next-line no-underscore-dangle
       const node = nodeTable.find((table) => table._key === this.node);
-      const incoming = (await api.edges(this.workspace, this.graph, {
+      const incoming = (await api.edges(this.workspace, this.network, {
         direction: 'incoming',
         offset: this.offsetIncoming,
         limit: this.pageCount,
       // eslint-disable-next-line no-underscore-dangle
       })).results.filter((edge) => edge._to === `${this.type}/${this.node}`);
-      const outgoing = (await api.edges(this.workspace, this.graph, {
+      const outgoing = (await api.edges(this.workspace, this.network, {
         direction: 'outgoing',
         offset: this.offsetOutgoing,
         limit: this.pageCount,

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -130,7 +130,7 @@
           >
             <network-panel
               :workspace="workspace"
-              :items="graphs"
+              :items="networks"
               :node-tables="nodeTables"
               :edge-tables="edgeTables"
               :loading="loading"
@@ -201,7 +201,7 @@ export default Vue.extend({
   computed: {
     nodeTables: () => store.getters.nodeTables,
     edgeTables: () => store.getters.edgeTables,
-    graphs: () => store.getters.graphs,
+    networks: () => store.getters.networks,
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     nameErrorMessages(this: any): string[] {

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -109,9 +109,9 @@ async function workspaceExists(p, name) {
   return workspaces.includes(name);
 }
 
-// Get the names of either all tables or all graphs in the current workspace
+// Get the names of either all tables or all networks in the current workspace
 async function getElementNames(elementType, p) {
-  // Search for the text of the table or graph elements
+  // Search for the text of the table or network elements
   await p.waitForSelector(`[data-title="${elementType}"] .ws-detail-empty-list`);
   const tables = await p.evaluate((elType) => {
     const titles = [];
@@ -125,7 +125,7 @@ async function getElementNames(elementType, p) {
   return tables;
 }
 
-// Checks if no tables or graphs exist in the current workspace
+// Checks if no tables or networks exist in the current workspace
 async function elementsEmpty(elementType, p) {
   const tables = await getElementNames(elementType, p);
   return tables.includes('info There\'s nothing here yet...');


### PR DESCRIPTION
Replaces all use of graph(s) with network(s) to maintain continuity across the frontend.  This includes the renaming of: 
- GraphDetail.vue
- DeleteGraphDialog.vue
- GraphCreateForm.vue
- GraphDialog.vue
- GraphUploadForm.vue

The only places where graph has not been replaced are in the urls which link to the visual applications (where a similar change has not been made).

Works in conjunction with the graph-to-network branch of [multinetjs](https://github.com/multinet-app/multinetjs/tree/graph-to-network).