### PR TITLE
Enable network and table creation/deletion based on permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.21",
     "material-design-icons-iconfont": "^5.0.1",
-    "multinet": "0.21.1",
+    "multinet": "0.21.2",
     "papaparse": "^5.3.0",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.8.2",

--- a/src/components/DeleteNetworkDialog.vue
+++ b/src/components/DeleteNetworkDialog.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
 
       await Promise.all(selection.map((network) => api.deleteNetwork(workspace, network)));
 
-      this.$emit('closed', [...selection]);
+      this.$emit('closed');
       this.dialog = false;
     },
   },

--- a/src/components/DeleteNetworkDialog.vue
+++ b/src/components/DeleteNetworkDialog.vue
@@ -132,8 +132,6 @@ export default Vue.extend({
       } = this;
 
       await Promise.all(selection.map((network) => api.deleteNetwork(workspace, network)));
-
-      this.$emit('closed');
       this.dialog = false;
     },
   },

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -182,7 +182,6 @@ export default Vue.extend({
 
       await Promise.all(selection.map((table) => api.deleteTable(workspace, table)));
 
-      this.$emit('closed');
       this.dialog = false;
       this.confirmation = '';
       this.confirmationPhrase = randomPhrase();

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -182,7 +182,7 @@ export default Vue.extend({
 
       await Promise.all(selection.map((table) => api.deleteTable(workspace, table)));
 
-      this.$emit('closed', [...selection]);
+      this.$emit('closed');
       this.dialog = false;
       this.confirmation = '';
       this.confirmationPhrase = randomPhrase();

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -205,7 +205,7 @@ export default Vue.extend({
     },
 
     editable(): boolean {
-      return this.$store.getters.hasRequiredPermission(RoleLevel.writer);
+      return store.getters.permissionLevel >= RoleLevel.writer;
     },
   },
 

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -29,6 +29,7 @@
       </div>
 
       <network-dialog
+        v-if="editable"
         :workspace="workspace"
         :node-tables="nodeTables"
         :edge-tables="edgeTables"
@@ -98,7 +99,7 @@
               </v-btn>
             </v-list-item-action>
             <v-list-item-action
-              v-if="hover"
+              v-if="hover && editable"
               class="mx-0 my-0"
               @click.prevent
             >
@@ -157,6 +158,11 @@ export default Vue.extend({
     },
 
     loading: {
+      type: Boolean as PropType<boolean>,
+      required: true,
+    },
+
+    editable: {
       type: Boolean as PropType<boolean>,
       required: true,
     },
@@ -230,15 +236,8 @@ export default Vue.extend({
       });
     },
 
-    async cleanup(selection?: string[]) {
+    async cleanup() {
       this.singleSelected = null;
-
-      if (selection) {
-        selection.forEach((item) => {
-          this.checkbox[item] = false;
-        });
-      }
-
       await store.dispatch.fetchWorkspace(this.workspace);
       this.clearCheckboxes();
     },

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -126,6 +126,7 @@ import NetworkDialog from '@/components/NetworkDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
+import { RoleLevel } from '@/utils/permissions';
 
 export default Vue.extend({
   name: 'NetworkPanel',
@@ -204,7 +205,7 @@ export default Vue.extend({
     },
 
     editable(): boolean {
-      return this.$store.getters.hasRequiredPermission('writer');
+      return this.$store.getters.hasRequiredPermission(RoleLevel.writer);
     },
   },
 

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -161,11 +161,6 @@ export default Vue.extend({
       type: Boolean as PropType<boolean>,
       required: true,
     },
-
-    editable: {
-      type: Boolean as PropType<boolean>,
-      required: true,
-    },
   },
 
   data() {
@@ -206,6 +201,10 @@ export default Vue.extend({
 
     anySelected(): boolean {
       return this.selection.length > 0;
+    },
+
+    editable(): boolean {
+      return this.$store.getters.hasRequiredPermission('writer');
     },
   },
 

--- a/src/components/PermissionsDialog.vue
+++ b/src/components/PermissionsDialog.vue
@@ -208,6 +208,7 @@ import store from '@/store';
 import {
   Role,
   SingularRole,
+  RoleLevel,
 } from '@/utils/permissions';
 
 export interface UserPermissionSpec {
@@ -247,7 +248,7 @@ export default Vue.extend({
   computed: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     workspacePermissionsEditable(this: any) {
-      return store.getters.hasRequiredPermission('maintainer');
+      return store.getters.hasRequiredPermission(RoleLevel.maintainer);
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     filteredWorkspacePermissions(this: any) {

--- a/src/components/PermissionsDialog.vue
+++ b/src/components/PermissionsDialog.vue
@@ -208,7 +208,6 @@ import store from '@/store';
 import {
   Role,
   SingularRole,
-  canChangeWorkspacePermissions,
 } from '@/utils/permissions';
 
 export interface UserPermissionSpec {
@@ -248,7 +247,7 @@ export default Vue.extend({
   computed: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     workspacePermissionsEditable(this: any) {
-      return canChangeWorkspacePermissions(store.state.userInfo, this.permissions);
+      return store.getters.hasRequiredPermission('maintainer');
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     filteredWorkspacePermissions(this: any) {

--- a/src/components/PermissionsDialog.vue
+++ b/src/components/PermissionsDialog.vue
@@ -200,9 +200,9 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import api from '@/api';
 import { WorkspacePermissionsSpec, UserSpec } from 'multinet';
 import { cloneDeep, debounce } from 'lodash';
+import api from '@/api';
 
 import store from '@/store';
 import {
@@ -248,7 +248,7 @@ export default Vue.extend({
   computed: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     workspacePermissionsEditable(this: any) {
-      return store.getters.hasRequiredPermission(RoleLevel.maintainer);
+      return store.getters.permissionLevel >= RoleLevel.maintainer;
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     filteredWorkspacePermissions(this: any) {

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -126,6 +126,7 @@ import TableDialog from '@/components/TableDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
+import { RoleLevel } from '@/utils/permissions';
 
 export default Vue.extend({
   name: 'TablePanel',
@@ -194,7 +195,7 @@ export default Vue.extend({
     },
 
     editable(): boolean {
-      return this.$store.getters.hasRequiredPermission('writer');
+      return this.$store.getters.hasRequiredPermission(RoleLevel.writer);
     },
   },
 

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
     },
 
     editable(): boolean {
-      return this.$store.getters.hasRequiredPermission(RoleLevel.writer);
+      return store.getters.permissionLevel >= RoleLevel.writer;
     },
   },
 

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -151,11 +151,6 @@ export default Vue.extend({
       type: Boolean as PropType<boolean>,
       required: true,
     },
-
-    editable: {
-      type: Boolean as PropType<boolean>,
-      required: true,
-    },
   },
 
   data() {
@@ -196,6 +191,10 @@ export default Vue.extend({
 
     anySelected(): boolean {
       return this.selection.length > 0;
+    },
+
+    editable(): boolean {
+      return this.$store.getters.hasRequiredPermission('writer');
     },
   },
 

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -30,6 +30,7 @@
       </div>
 
       <table-dialog
+        v-if="editable"
         :workspace="workspace"
         @success="cleanup"
       />
@@ -99,7 +100,7 @@
               </v-btn>
             </v-list-item-action>
             <v-list-item-action
-              v-if="hover"
+              v-if="hover && editable"
               class="mx-0 my-0"
               @click.prevent
             >
@@ -148,6 +149,11 @@ export default Vue.extend({
     },
 
     loading: {
+      type: Boolean as PropType<boolean>,
+      required: true,
+    },
+
+    editable: {
       type: Boolean as PropType<boolean>,
       required: true,
     },

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -24,7 +24,6 @@
           ref="deleter"
           :selection="selection"
           :workspace="workspace"
-          @deleted="cleanup"
           @closed="cleanup"
         />
       </div>
@@ -227,15 +226,8 @@ export default Vue.extend({
       });
     },
 
-    async cleanup(selection?: string[]) {
+    async cleanup() {
       this.singleSelected = null;
-
-      if (selection) {
-        selection.forEach((item) => {
-          this.checkbox[item] = false;
-        });
-      }
-
       await store.dispatch.fetchWorkspace(this.workspace);
       this.clearCheckboxes();
     },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,7 +5,7 @@ import { SingleUserWorkspacePermissionSpec, UserSpec } from 'multinet';
 
 import api from '@/api';
 import oauthClient from '@/oauth';
-import { SingularRole, RoleOrdering } from '@/utils/permissions';
+import { SingularRole, getRoleOrdinal } from '@/utils/permissions';
 
 Vue.use(Vuex);
 
@@ -58,28 +58,13 @@ const {
       return [];
     },
 
-    canEditWorkspace(state: State): boolean {
-      if (!state.currentWorkspacePermissionInfo) {
-        return false;
-      }
-      const { permission } = state.currentWorkspacePermissionInfo;
-      switch (permission) {
-        case 'owner':
-        case 'maintainer':
-        case 'writer':
-          return true;
-        default:
-          return false;
-      }
-    },
-
     hasRequiredPermission: (state: State) => (minimumPermission: SingularRole) => {
       if (!state.currentWorkspacePermissionInfo) {
         return false;
       }
 
       const { permission } = state.currentWorkspacePermissionInfo;
-      return RoleOrdering[permission as SingularRole] >= RoleOrdering[minimumPermission];
+      return getRoleOrdinal(permission as SingularRole) >= getRoleOrdinal(minimumPermission);
     },
   },
   mutations: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,7 +20,7 @@ export interface State {
   workspaces: string[];
   currentWorkspace: WorkspaceState | null;
   userInfo: UserSpec | null;
-  currentWorkspacePermissionInfo: SingleUserWorkspacePermissionSpec | null;
+  currentWorkspacePermission: SingleUserWorkspacePermissionSpec | null;
 }
 
 const {
@@ -34,7 +34,7 @@ const {
     workspaces: [],
     currentWorkspace: null,
     userInfo: null,
-    currentWorkspacePermissionInfo: null,
+    currentWorkspacePermission: null,
   } as State,
   getters: {
     nodeTables(state: State): string[] {
@@ -58,13 +58,15 @@ const {
       return [];
     },
 
-    hasRequiredPermission: (state: State) => (minimumPermission: RoleLevel) => {
-      if (!state.currentWorkspacePermissionInfo) {
-        return false;
+    permissionLevel(state: State): RoleLevel {
+      if (!state.currentWorkspacePermission) {
+        return RoleLevel.none;
       }
-
-      const { permission } = state.currentWorkspacePermissionInfo;
-      return permission && permission >= minimumPermission;
+      const { permission } = state.currentWorkspacePermission;
+      if (!permission) {
+        return RoleLevel.none;
+      }
+      return permission as RoleLevel;
     },
   },
   mutations: {
@@ -85,7 +87,7 @@ const {
     },
 
     setPermissionInfo(state, permissionInfo: SingleUserWorkspacePermissionSpec | null) {
-      state.currentWorkspacePermissionInfo = permissionInfo;
+      state.currentWorkspacePermission = permissionInfo;
     },
   },
   actions: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,7 +5,7 @@ import { SingleUserWorkspacePermissionSpec, UserSpec } from 'multinet';
 
 import api from '@/api';
 import oauthClient from '@/oauth';
-import { SingularRole, getRoleOrdinal } from '@/utils/permissions';
+import { RoleLevel } from '@/utils/permissions';
 
 Vue.use(Vuex);
 
@@ -58,13 +58,13 @@ const {
       return [];
     },
 
-    hasRequiredPermission: (state: State) => (minimumPermission: SingularRole) => {
+    hasRequiredPermission: (state: State) => (minimumPermission: RoleLevel) => {
       if (!state.currentWorkspacePermissionInfo) {
         return false;
       }
 
       const { permission } = state.currentWorkspacePermissionInfo;
-      return getRoleOrdinal(permission as SingularRole) >= getRoleOrdinal(minimumPermission);
+      return permission && permission >= minimumPermission;
     },
   },
   mutations: {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,18 +1,9 @@
-import { WorkspacePermissionsSpec, UserSpec } from 'multinet';
-
 export type Role = 'owner' | 'maintainers' | 'writers' | 'readers';
 export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader';
 
-export function canChangeWorkspacePermissions(userInfo: UserSpec | null, permissions: WorkspacePermissionsSpec | null): boolean {
-  if (!userInfo || !permissions) { return false; }
-
-  const userId = userInfo.id;
-  const ownerId = permissions.owner.id;
-  const maintainerIds = permissions.maintainers.map((user) => user.id);
-
-  if (maintainerIds.includes(userId) || userId === ownerId) {
-    return true;
-  }
-
-  return false;
-}
+export const RoleOrdering: Record<SingularRole, number> = {
+  owner: 4,
+  maintainer: 3,
+  writer: 2,
+  reader: 1,
+};

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,9 +1,17 @@
 export type Role = 'owner' | 'maintainers' | 'writers' | 'readers';
-export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader';
+export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader' | null;
 
-export const RoleOrdering: Record<SingularRole, number> = {
-  owner: 4,
-  maintainer: 3,
-  writer: 2,
-  reader: 1,
-};
+export function getRoleOrdinal(role: SingularRole): number {
+  switch (role) {
+    case 'owner':
+      return 4;
+    case 'maintainer':
+      return 3;
+    case 'writer':
+      return 2;
+    case 'reader':
+      return 1;
+    default:
+      return 0;
+  }
+}

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -6,4 +6,5 @@ export enum RoleLevel {
   maintainer = 3,
   writer = 2,
   reader = 1,
+  none = 0,
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,17 +1,9 @@
 export type Role = 'owner' | 'maintainers' | 'writers' | 'readers';
 export type SingularRole = 'owner' | 'maintainer' | 'writer' | 'reader' | null;
 
-export function getRoleOrdinal(role: SingularRole): number {
-  switch (role) {
-    case 'owner':
-      return 4;
-    case 'maintainer':
-      return 3;
-    case 'writer':
-      return 2;
-    case 'reader':
-      return 1;
-    default:
-      return 0;
-  }
+export enum RoleLevel {
+  owner = 4,
+  maintainer = 3,
+  writer = 2,
+  reader = 1,
 }

--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -119,13 +119,12 @@
 
 <script lang="ts">
 
-import api from '@/api';
-import store from '@/store';
-import { PropType } from 'vue';
-
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import VueJsonPretty from 'vue-json-pretty';
+import { PropType } from 'vue';
+import api from '@/api';
+import store from '@/store';
 
 type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
 interface JsonMap { [key: string]: AnyJson }

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -152,6 +152,7 @@
               :workspace="workspace"
               :items="tables"
               :loading="loading"
+              :editable="false"
             />
           </v-card>
         </v-flex>
@@ -280,7 +281,7 @@ export default Vue.extend({
 
       this.localWorkspace = this.workspace;
       await store.dispatch.fetchWorkspace(this.workspace);
-
+      await store.dispatch.fetchPermissionsInfo(this.workspace);
       this.loading = false;
     },
   },

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -152,7 +152,6 @@
               :workspace="workspace"
               :items="tables"
               :loading="loading"
-              :editable="false"
             />
           </v-card>
         </v-flex>
@@ -281,7 +280,6 @@ export default Vue.extend({
 
       this.localWorkspace = this.workspace;
       await store.dispatch.fetchWorkspace(this.workspace);
-      await store.dispatch.fetchPermissionsInfo(this.workspace);
       this.loading = false;
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6162,10 +6162,10 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-multinet@0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.21.1.tgz#a16633a23a2bcbc7a998c2cda0c4cc5870d0fcad"
-  integrity sha512-XS92S4DOPGTzWUIesEdqQ4megekPyEI5EOBf3C+8t1rbmy51s4zqReXdll0+poS4YoUAQRxyoMSo9T6Ktwg1Fg==
+multinet@0.21.2:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.21.2.tgz#724d1dcae8b8b338a17d3ae717fb9f73e65a145d"
+  integrity sha512-EVbGYfW2VHhohSaUnUyCMSEF918Zn17Vo5wJcfMFA8+idyB/wbNqwr/ZC45aDXZJ/94BZbQigR1FcjbAOXM9NA==
   dependencies:
     axios "^0.21.1"
     django-s3-file-field "^0.1.2"


### PR DESCRIPTION
Closes #140 

This PR updated the client application code to utilize the new API endpoint `GET /api/workspaces/{workspace}/permissions/me/`.

Specifically, the following changes are made:

1. Update the Vuex store to track the current user's permission on the currently selected workspace
2. Add a `getter` to the Vuex store to check permission level. This includes a new utility function to help with permission checking
3. Use this new `getter` in the `PermissionDialog` component instead of the function defined in `utils/permission.ts`
4. Update `NetworkPanel` and `TablePanel` to use the new `getter` to enable/disable functionality based on permission level
5. Remove use of `selection` parameter in `DeleteTableDialog` and `DeleteNetworkDialog`, as its use was redundant 