### PR TITLE
Guess the column types from the first 1000 rows

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -56,16 +56,23 @@ async function analyzeCSV(file: File): Promise<CSVAnalysis> {
     const columnTypes = new Map<string, TypeScore>();
     const typeRecs = new Map<string, CSVColumnType>();
     const sampleRows = [] as Array<{}>;
+    let rowsParsed = 0;
 
     Papa.parse(file, {
       header: true,
       skipEmptyLines: true,
-      step(row: ParseResult<{}>) {
+      step(row: ParseResult<{}>, parser) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data = row.data as { [key: string]: any };
 
         if (sampleRows.length !== 30) {
           sampleRows.push({ ...data });
+        }
+
+        // Increment number of rows parsed and return if we've done 1000
+        rowsParsed += 1;
+        if (rowsParsed === 1000) {
+          parser.abort();
         }
 
         Object.keys(data).forEach((key: string) => {


### PR DESCRIPTION
Closes #195

Instead of parsing the whole dataset to guess the types for the columns, we can just parse the first thousand rows. This helps the run time -- it's basically instant. That means the preview rows will have loaded by the time you're looking at type specifying page in the stepper.

I tried to use the papaparse `preview` [option](https://www.papaparse.com/docs#config), but I think the `step` callback overrides that. To get around that issue I implemented a counter that will trigger the parser to abort when we hit that number.

The types suggested were identical on my test set with either so I think this is pretty robust.

We'll need some better error UI in the future to alert users to any parsing issues, but this has never been implemented and shouldn't slow this PR down.