### PR TITLE
Network-in-querystring

### DIFF
--- a/src/views/FrontPage.vue
+++ b/src/views/FrontPage.vue
@@ -167,28 +167,28 @@ export default Vue.extend({
           // eslint-disable-next-line global-require
           image: require('../assets/placard/boston.jpg'),
           text: 'Explore the Paul Revere dataset using an interactive and beautiful node-link diagram. Discover the figures coordinating a pivotal event in history!',
-          href: `${this.multiLinkURL}/?workspace=boston&graph=boston`,
+          href: `${this.multiLinkURL}/?workspace=boston&network=boston`,
         },
         {
           title: 'Les Miserables - MultiMatrix',
           // eslint-disable-next-line global-require
           image: require('../assets/placard/miserables.jpg'),
           text: 'Explore the Les Miserables dataset using an interactive adjacency matrix. See the factions and relationships for yourself!',
-          href: `${this.multiMatrixURL}/?workspace=miserables&graph=miserables`,
+          href: `${this.multiMatrixURL}/?workspace=miserables&network=miserables`,
         },
         {
           title: 'Les Miserables - MultiLink',
           // eslint-disable-next-line global-require
           image: require('../assets/placard/miserables2.jpg'),
           text: 'The characters of Les Miserables, laid out in a colorful and interactive node-link diagram.',
-          href: `${this.multiLinkURL}/?workspace=miserables&graph=miserables`,
+          href: `${this.multiLinkURL}/?workspace=miserables&network=miserables`,
         },
         {
           title: 'Paul Revere - MultiMatrix',
           // eslint-disable-next-line global-require
           image: require('../assets/placard/boston2.jpg'),
           text: 'See the relationships between Paul Revere and his contemporaries through an adjacency matrix layout.',
-          href: `${this.multiMatrixURL}/?workspace=boston&graph=boston`,
+          href: `${this.multiMatrixURL}/?workspace=boston&network=boston`,
         },
       ];
     },


### PR DESCRIPTION
Closes #90

Will require equivalent PRs on the clients

Looks most of the querystrings were already updated, but there were a few spots that we missed. I've updated them here and will update the vis apps so that when we transition to the new API, everything is working as we expect