### PR TITLE
Disable add network/table button on network overview if user lacks permissions

### DIFF
--- a/src/components/NetworkDialog.vue
+++ b/src/components/NetworkDialog.vue
@@ -9,7 +9,7 @@
         color="blue darken-2"
         icon
         medium
-        :disabled="!editable"
+        :disabled="!userCanEdit"
         v-on="on"
       >
         <v-icon dark>
@@ -53,7 +53,6 @@ import Vue, { PropType } from 'vue';
 import NetworkCreateForm from '@/components/NetworkCreateForm.vue';
 import NetworkUploadForm from '@/components/NetworkUploadForm.vue';
 import store from '@/store';
-import { RoleLevel } from '@/utils/permissions';
 
 export default Vue.extend({
   name: 'NetworkDialog',
@@ -78,8 +77,8 @@ export default Vue.extend({
     };
   },
   computed: {
-    editable(): boolean {
-      return store.getters.permissionLevel >= RoleLevel.writer;
+    userCanEdit(): boolean {
+      return store.getters.userCanEdit;
     },
   },
   methods: {

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -98,7 +98,7 @@
               </v-btn>
             </v-list-item-action>
             <v-list-item-action
-              v-if="hover && editable"
+              v-if="hover && userCanEdit"
               class="mx-0 my-0"
               @click.prevent
             >
@@ -125,7 +125,6 @@ import NetworkDialog from '@/components/NetworkDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
-import { RoleLevel } from '@/utils/permissions';
 
 export default Vue.extend({
   name: 'NetworkPanel',
@@ -203,8 +202,8 @@ export default Vue.extend({
       return this.selection.length > 0;
     },
 
-    editable(): boolean {
-      return store.getters.permissionLevel >= RoleLevel.writer;
+    userCanEdit(): boolean {
+      return store.getters.userCanEdit;
     },
   },
 

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -9,7 +9,7 @@
         color="blue darken-2"
         icon
         medium
-        :disabled="!editable"
+        :disabled="!userCanEdit"
         v-on="on"
       >
         <v-icon dark>
@@ -181,7 +181,6 @@ import {
 import api from '@/api';
 import { TableFileType, CSVColumnType } from '@/types';
 import { validFileType, fileName as getFileName, analyzeCSV } from '@/utils/files';
-import { RoleLevel } from '@/utils/permissions';
 import store from '@/store';
 
 const defaultKeyField = '_key';
@@ -322,7 +321,7 @@ export default defineComponent({
       }
     }
 
-    const editable = computed(() => store.getters.permissionLevel >= RoleLevel.writer);
+    const userCanEdit = computed(() => store.getters.userCanEdit);
 
     return {
       step,
@@ -343,7 +342,7 @@ export default defineComponent({
       restoreKeyField,
       keyField,
       overwrite,
-      editable,
+      userCanEdit,
     };
   },
 });

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -98,7 +98,7 @@
               </v-btn>
             </v-list-item-action>
             <v-list-item-action
-              v-if="hover && editable"
+              v-if="hover && userCanEdit"
               class="mx-0 my-0"
               @click.prevent
             >
@@ -125,7 +125,6 @@ import TableDialog from '@/components/TableDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
-import { RoleLevel } from '@/utils/permissions';
 
 export default Vue.extend({
   name: 'TablePanel',
@@ -193,8 +192,8 @@ export default Vue.extend({
       return this.selection.length > 0;
     },
 
-    editable(): boolean {
-      return store.getters.permissionLevel >= RoleLevel.writer;
+    userCanEdit(): boolean {
+      return store.getters.userCanEdit;
     },
   },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -68,6 +68,10 @@ const {
       }
       return permission as RoleLevel;
     },
+
+    userCanEdit(state, getters) {
+      return getters.permissionLevel >= RoleLevel.writer;
+    },
   },
   mutations: {
     setWorkspaces(state, workspaces: string[]) {


### PR DESCRIPTION
Closes #83

After the girder changes, I have access to the permission levels to disable the creation of networks and tables. The current behavior is to hide the icons, but this PR disables them instead so it's more clear to users that it's disabled and not just bugged. The first attempt at this change was #156, but after the girder changes, a new PR makes sense. 

bb2902c removes some redundant code by adding a store getter that determines whether a user can edit the workspace they're in.

Signed out:
![image](https://user-images.githubusercontent.com/36867477/138000531-74a19cea-ce2e-41bd-9386-76790581ad4a.png)