### PR TITLE
Remove an extra question mark from the delete dialog

### DIFF
--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -38,7 +38,7 @@
 
       <v-card-text class="px-5 py-4">
         You are about to delete {{ selection.length }} table{{ plural }}. Type the
-        following phrase to confirm: <strong>{{ confirmationPhrase }}?</strong>
+        following phrase to confirm: <strong>{{ confirmationPhrase }}</strong>
       </v-card-text>
 
       <v-card-text>


### PR DESCRIPTION
Found this when deleting a bunch of tables. With the question mark, it's unclear whether that is a part of the string to be typed or not.

The phrase is clearly not a question so I removed it