### PR TITLE
Address various papercuts in the UI/UX

### DIFF
--- a/src/components/DeleteNetworkDialog.vue
+++ b/src/components/DeleteNetworkDialog.vue
@@ -134,8 +134,6 @@ export default Vue.extend({
 
       await Promise.all(selection.map((network) => api.deleteNetwork(workspace, network)));
       this.dialog = false;
-
-      this.clear();
     },
 
     clear() {

--- a/src/components/DeleteNetworkDialog.vue
+++ b/src/components/DeleteNetworkDialog.vue
@@ -117,6 +117,7 @@ export default Vue.extend({
   watch: {
     dialog() {
       if (this.dialog) {
+        this.clear();
         this.confirmationPhrase = randomPhrase();
       } else {
         this.$emit('closed');
@@ -133,6 +134,13 @@ export default Vue.extend({
 
       await Promise.all(selection.map((network) => api.deleteNetwork(workspace, network)));
       this.dialog = false;
+
+      this.clear();
+    },
+
+    clear() {
+      this.confirmationPhrase = '';
+      this.confirmation = '';
     },
   },
 });

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -165,6 +165,7 @@ export default Vue.extend({
         if (using.length > 0) {
           this.using = using;
         } else {
+          this.clear();
           this.confirmationPhrase = randomPhrase();
         }
       } else {
@@ -181,10 +182,14 @@ export default Vue.extend({
       } = this;
 
       await Promise.all(selection.map((table) => api.deleteTable(workspace, table)));
-
       this.dialog = false;
+
+      this.clear();
+    },
+
+    clear() {
+      this.confirmationPhrase = '';
       this.confirmation = '';
-      this.confirmationPhrase = randomPhrase();
     },
 
     async findDependentNetworks() {

--- a/src/components/DeleteTableDialog.vue
+++ b/src/components/DeleteTableDialog.vue
@@ -183,8 +183,6 @@ export default Vue.extend({
 
       await Promise.all(selection.map((table) => api.deleteTable(workspace, table)));
       this.dialog = false;
-
-      this.clear();
     },
 
     clear() {

--- a/src/components/DeleteWorkspaceDialog.vue
+++ b/src/components/DeleteWorkspaceDialog.vue
@@ -123,6 +123,7 @@ export default Vue.extend({
   watch: {
     dialog() {
       if (this.dialog) {
+        this.clear();
         this.confirmationPhrase = randomPhrase();
       } else {
         this.$emit('closed');
@@ -138,10 +139,17 @@ export default Vue.extend({
 
       await Promise.all(selection.map((ws) => api.deleteWorkspace(ws)));
 
+      this.clear();
+
       store.dispatch.fetchWorkspaces();
       this.$emit('deleted');
 
       this.dialog = false;
+    },
+
+    clear() {
+      this.confirmationPhrase = '';
+      this.confirmation = '';
     },
   },
 });

--- a/src/components/DeleteWorkspaceDialog.vue
+++ b/src/components/DeleteWorkspaceDialog.vue
@@ -139,8 +139,6 @@ export default Vue.extend({
 
       await Promise.all(selection.map((ws) => api.deleteWorkspace(ws)));
 
-      this.clear();
-
       store.dispatch.fetchWorkspaces();
       this.$emit('deleted');
 

--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -80,7 +80,7 @@ export default {
       const userInfo = this.userInfo as unknown as UserSpec | null;
 
       if (userInfo !== null) {
-        return `${userInfo.first_name[0]}${userInfo.last_name[0]}`;
+        return `${userInfo.first_name[0] || ''}${userInfo.last_name[0] || ''}`;
       }
       return '';
     },

--- a/src/components/NetworkCreateForm.vue
+++ b/src/components/NetworkCreateForm.vue
@@ -32,7 +32,9 @@
       <v-spacer />
       <v-btn
         depressed
-        :disabled="networkCreateDisabled"
+        color="primary"
+        :disabled="networkCreateDisabled || loading"
+        :loading="loading"
         @click="createNetwork"
       >
         create network
@@ -64,6 +66,7 @@ export default Vue.extend({
       networkCreationErrors: [] as string[],
       networkEdgeTable: null as string | null,
       newNetwork: '',
+      loading: false,
     };
   },
   computed: {
@@ -80,15 +83,23 @@ export default Vue.extend({
       }
 
       try {
+        this.loading = true;
         await api.createNetwork(workspace, newNetwork, {
           edgeTable: this.networkEdgeTable,
         });
         this.networkCreationErrors = [];
+        this.clear();
         this.$emit('success');
       } catch (error) {
         const message = `Network "${this.newNetwork}" already exists.`;
         this.networkCreationErrors = [message];
       }
+    },
+
+    clear() {
+      this.networkEdgeTable = null;
+      this.newNetwork = '';
+      this.loading = false;
     },
   },
 });

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -163,6 +163,8 @@
             <v-btn
               color="primary"
               depressed
+              :loading="loading"
+              :disabled="loading"
               @click="createTable"
             >
               Create Table
@@ -275,6 +277,7 @@ export default defineComponent({
     const tableDialog = ref(false);
     const tableCreationError = ref<string | null>(null);
     const createDisabled = computed(() => selectedFile.value === null || !fileName.value);
+    const loading = ref(false);
     async function createTable() {
       if (selectedFile.value === null || fileName.value === null) {
         return;
@@ -284,6 +287,7 @@ export default defineComponent({
       uploading.value = true;
 
       try {
+        loading.value = true;
         await api.uploadTable(workspace, fileName.value, {
           data: selectedFile.value,
           edgeTable: edgeTable.value,
@@ -292,6 +296,7 @@ export default defineComponent({
 
         tableCreationError.value = null;
         tableDialog.value = false;
+        loading.value = false;
 
         emit('success');
         resetAllFields();
@@ -319,6 +324,7 @@ export default defineComponent({
       uploading,
       uploadProgress,
       createDisabled,
+      loading,
       createTable,
       restoreKeyField,
       keyField,

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -32,8 +32,10 @@
         <v-stepper-step
           :complete="step > 2"
           step="2"
+          :rules="[() => tableCreationError === null]"
         >
           Set Column Types
+          <small>{{ tableCreationError }}</small>
         </v-stepper-step>
       </v-stepper-header>
 
@@ -62,7 +64,6 @@
                   <v-flex>
                     <v-text-field
                       v-model="fileName"
-                      :error-messages="tableCreationError"
                       label="Table Name"
                       outlined
                       dense
@@ -226,10 +227,14 @@ export default defineComponent({
     // Type recommendation
     const columnType: Ref<{[key: string]: CSVColumnType}> = ref({});
 
+    const tableCreationError = ref<string | null>(null);
+
     // File selection
     const selectedFile = ref<File | null>(null);
     const fileName = ref<string | null>(null);
     watch(selectedFile, async (newFile) => {
+      tableCreationError.value = null;
+
       if (newFile === null) {
         fileName.value = null;
         columnType.value = {};
@@ -275,7 +280,6 @@ export default defineComponent({
 
     // Table creation state
     const tableDialog = ref(false);
-    const tableCreationError = ref<string | null>(null);
     const createDisabled = computed(() => selectedFile.value === null || !fileName.value);
     const loading = ref(false);
     async function createTable() {
@@ -301,7 +305,7 @@ export default defineComponent({
         emit('success');
         resetAllFields();
       } catch (err) {
-        tableCreationError.value = err.statusText;
+        tableCreationError.value = `${Object.values(err.response.data).flat()[0]}`;
       } finally {
         uploading.value = false;
         uploadProgress.value = null;

--- a/src/components/WorkspaceOptionMenu.vue
+++ b/src/components/WorkspaceOptionMenu.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-menu
+    v-model="actionsMenu"
+    max-width="275"
+    offset-y
+    origin="center center"
+    transition="scale-transition"
+  >
+    <template v-slot:activator="{ on }">
+      <v-btn
+        icon
+        v-on="on"
+      >
+        <v-icon>more_vert</v-icon>
+      </v-btn>
+    </template>
+    <v-card>
+      <v-list
+        dense
+        width="224"
+      >
+        <!-- Each listing here should contain a v-list-item -->
+        <PermissionsDialog :workspace="workspace" />
+        <v-list-item :to="{ name: 'aqlWizard' }">
+          <v-list-item-icon class="mr-3">
+            <v-icon>search</v-icon>
+          </v-list-item-icon>
+          <v-list-item-content>
+            AQL Wizard
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </v-menu>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType, ref } from '@vue/composition-api';
+import PermissionsDialog from '@/components/PermissionsDialog.vue';
+
+export default defineComponent({
+  components: {
+    PermissionsDialog,
+  },
+
+  props: {
+    workspace: {
+      type: String as PropType<string>,
+      required: true,
+    },
+  },
+
+  setup() {
+    const actionsMenu = ref(false);
+
+    return {
+      actionsMenu,
+    };
+  },
+});
+</script>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,23 +37,30 @@ const {
     currentWorkspacePermission: null,
   } as State,
   getters: {
+    tables(state: State, getters): string[] {
+      if (state.currentWorkspace !== null && state.currentWorkspace.nodeTables && state.currentWorkspace.edgeTables) {
+        return getters.nodeTables.concat(getters.edgeTables).sort();
+      }
+      return [];
+    },
+
     nodeTables(state: State): string[] {
       if (state.currentWorkspace !== null && state.currentWorkspace.nodeTables) {
-        return state.currentWorkspace.nodeTables;
+        return state.currentWorkspace.nodeTables.sort();
       }
       return [];
     },
 
     edgeTables(state: State): string[] {
       if (state.currentWorkspace !== null && state.currentWorkspace.edgeTables) {
-        return state.currentWorkspace.edgeTables;
+        return state.currentWorkspace.edgeTables.sort();
       }
       return [];
     },
 
     networks(state: State) {
       if (state.currentWorkspace !== null && state.currentWorkspace.networks) {
-        return state.currentWorkspace.networks;
+        return state.currentWorkspace.networks.sort();
       }
       return [];
     },
@@ -75,7 +82,7 @@ const {
   },
   mutations: {
     setWorkspaces(state, workspaces: string[]) {
-      state.workspaces = workspaces;
+      state.workspaces = workspaces.sort();
     },
 
     setCurrentWorkspace(state, workspace: WorkspaceState) {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,15 +1,6 @@
 import Papa, { ParseResult } from 'papaparse';
 import dayjs from 'dayjs';
-import { validUploadType } from 'multinet';
-import { FileType, CSVColumnType } from '@/types';
-
-const fileExtension = (file: File) => file.name.split('.').slice(-1)[0];
-const fileName = (file: File) => file.name.split('.')[0];
-
-function validFileType(file: File, allowedTypes: readonly FileType[]) {
-  const extension = fileExtension(file);
-  return allowedTypes.some((type) => type.extension.includes(extension) && validUploadType(type.queryCall));
-}
+import { CSVColumnType } from '@/types';
 
 function isBoolean(strings: Set<string>) {
   // This function tests whether both elements of an array belong to the string
@@ -150,7 +141,5 @@ async function analyzeCSV(file: File): Promise<CSVAnalysis> {
 }
 
 export {
-  fileName,
-  validFileType,
   analyzeCSV,
 };

--- a/src/views/NetworkDetail.vue
+++ b/src/views/NetworkDetail.vue
@@ -441,6 +441,8 @@ export default Vue.extend({
         }
       });
       this.edgeTypes = edges.results.length > 0 ? [tableName(edges.results[0])] : [];
+      this.nodeTypes = this.nodeTypes.sort();
+      this.edgeTypes = this.edgeTypes.sort();
 
       // eslint-disable-next-line no-underscore-dangle
       this.nodes = nodes.results.map((node) => node._id);

--- a/src/views/NetworkDetail.vue
+++ b/src/views/NetworkDetail.vue
@@ -40,9 +40,7 @@
 
       <v-spacer />
 
-      <v-btn icon>
-        <v-icon>more_vert</v-icon>
-      </v-btn>
+      <workspace-option-menu :workspace="workspace" />
     </v-app-bar>
     <v-main class="fill-height">
       <v-container
@@ -327,12 +325,18 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { EdgesSpec, TableRow } from 'multinet';
+import WorkspaceOptionMenu from '@/components/WorkspaceOptionMenu.vue';
 
 import api from '@/api';
 import { App } from '@/types';
 
 export default Vue.extend({
   name: 'NetworkDetail',
+
+  components: {
+    WorkspaceOptionMenu,
+  },
+
   props: {
     workspace: {
       type: String as PropType<string>,

--- a/src/views/NodeDetail.vue
+++ b/src/views/NodeDetail.vue
@@ -52,9 +52,7 @@
 
         <v-spacer />
 
-        <v-btn icon>
-          <v-icon>more_vert</v-icon>
-        </v-btn>
+        <workspace-option-menu :workspace="workspace" />
       </v-app-bar>
 
       <v-container
@@ -262,6 +260,7 @@ import { EdgesSpec } from 'multinet';
 
 import api from '@/api';
 import { KeyValue } from '@/types';
+import WorkspaceOptionMenu from '@/components/WorkspaceOptionMenu.vue';
 
 interface EdgeRecord {
   id: string;
@@ -278,6 +277,11 @@ type EdgeType = 'incoming' | 'outgoing';
 
 export default Vue.extend({
   name: 'NodeDetail',
+
+  components: {
+    WorkspaceOptionMenu,
+  },
+
   props: {
     workspace: {
       type: String as PropType<string>,

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -81,9 +81,7 @@
 
         <v-spacer />
 
-        <v-btn icon>
-          <v-icon>more_vert</v-icon>
-        </v-btn>
+        <workspace-option-menu :workspace="workspace" />
       </v-app-bar>
       <div class="wrapper">
         <v-data-table
@@ -129,6 +127,7 @@ import Vue, { PropType } from 'vue';
 import api from '@/api';
 import { KeyValue, TableRow } from '@/types';
 import store from '@/store';
+import WorkspaceOptionMenu from '@/components/WorkspaceOptionMenu.vue';
 
 interface DataPagination {
   page: number;
@@ -141,6 +140,11 @@ interface DataPagination {
 
 export default Vue.extend({
   name: 'TableDetail',
+
+  components: {
+    WorkspaceOptionMenu,
+  },
+
   props: {
     workspace: {
       type: String as PropType<string>,

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -128,6 +128,7 @@ import Vue, { PropType } from 'vue';
 
 import api from '@/api';
 import { KeyValue, TableRow } from '@/types';
+import store from '@/store';
 
 interface DataPagination {
   page: number;
@@ -155,7 +156,6 @@ export default Vue.extend({
     return {
       rowKeys: [] as KeyValue[][],
       headers: [] as Array<keyof TableRow>,
-      tables: [] as string[],
       editing: false,
       tableSize: 1,
       pagination: {} as DataPagination,
@@ -163,6 +163,7 @@ export default Vue.extend({
     };
   },
   computed: {
+    tables: () => store.getters.tables,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     dataTableHeaders(this: any) {
       const {
@@ -270,11 +271,6 @@ export default Vue.extend({
 
       this.rowKeys = rowKeys;
       this.headers = headers;
-
-      // Roni to convert these lines to computed function
-      this.tables = (await api.tables(this.workspace, {
-        type: 'all',
-      })).results.map((table) => table.name);
 
       this.loading = false;
     },

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -18,7 +18,7 @@
 
           <v-divider />
 
-          <div v-if="loading">
+          <div v-if="loadingTables">
             <v-skeleton-loader type="list-item" />
             <v-skeleton-loader type="list-item" />
             <v-skeleton-loader type="list-item" />
@@ -160,6 +160,7 @@ export default Vue.extend({
       tableSize: 1,
       pagination: {} as DataPagination,
       loading: true,
+      loadingTables: true,
     };
   },
   computed: {
@@ -219,9 +220,18 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tables(this: any) {
+      this.loadingTables = false;
+    },
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     pagination(this: any) {
       this.update();
     },
+  },
+
+  created() {
+    store.dispatch.fetchWorkspace(this.workspace);
   },
 
   methods: {

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -228,7 +228,8 @@ export default Vue.extend({
           if (err.response.status === 409) {
             this.requestError = 'A workspace by that name already exists';
           } else {
-            this.requestError = err.response.statusText;
+            console.log(err.response);
+            this.requestError = `${Object.values(err.response.data).flat()[0]}`;
           }
         }
       }

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -201,6 +201,7 @@ export default Vue.extend({
   computed: {
     nodeTables: () => store.getters.nodeTables,
     edgeTables: () => store.getters.edgeTables,
+    tables: () => store.getters.tables,
     networks: () => store.getters.networks,
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -212,14 +213,6 @@ export default Vue.extend({
       ];
 
       return errors.filter((res): res is string => typeof res === 'string');
-    },
-    tables(): string[] {
-      const {
-        nodeTables,
-        edgeTables,
-      } = this;
-
-      return nodeTables.concat(edgeTables);
     },
   },
 

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -80,39 +80,7 @@
         />
         <v-spacer />
 
-        <v-menu
-          v-model="actionsMenu"
-          max-width="275"
-          offset-y
-          origin="center center"
-          transition="scale-transition"
-        >
-          <template v-slot:activator="{ on }">
-            <v-btn
-              icon
-              v-on="on"
-            >
-              <v-icon>more_vert</v-icon>
-            </v-btn>
-          </template>
-          <v-card>
-            <v-list
-              dense
-              width="224"
-            >
-              <!-- Each listing here should contain a v-list-item -->
-              <PermissionsDialog :workspace="workspace" />
-              <v-list-item :to="{ name: 'aqlWizard' }">
-                <v-list-item-icon class="mr-3">
-                  <v-icon>search</v-icon>
-                </v-list-item-icon>
-                <v-list-item-content>
-                  AQL Wizard
-                </v-list-item-content>
-              </v-list-item>
-            </v-list>
-          </v-card>
-        </v-menu>
+        <workspace-option-menu :workspace="workspace" />
       </v-app-bar>
 
       <v-layout
@@ -166,8 +134,8 @@ import Vue, { PropType } from 'vue';
 import api from '@/api';
 import TablePanel from '@/components/TablePanel.vue';
 import NetworkPanel from '@/components/NetworkPanel.vue';
-import PermissionsDialog from '@/components/PermissionsDialog.vue';
 import store from '@/store';
+import WorkspaceOptionMenu from '@/components/WorkspaceOptionMenu.vue';
 
 const surroundingWhitespace = /^\s+|\s+$/;
 const workspaceNameRules: Array<(x: string) => string|boolean> = [
@@ -180,7 +148,7 @@ export default Vue.extend({
   components: {
     TablePanel,
     NetworkPanel,
-    PermissionsDialog,
+    WorkspaceOptionMenu,
   },
   props: {
     workspace: {
@@ -194,7 +162,6 @@ export default Vue.extend({
       editing: false,
       requestError: null as string | null,
       loading: false,
-      actionsMenu: false,
     };
   },
 

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -228,7 +228,6 @@ export default Vue.extend({
           if (err.response.status === 409) {
             this.requestError = 'A workspace by that name already exists';
           } else {
-            console.log(err.response);
             this.requestError = `${Object.values(err.response.data).flat()[0]}`;
           }
         }


### PR DESCRIPTION
As I've been using the app I've noticed many small UX issues that make the app harder to use. This is a first attempt at addressing some of the more heinous ones:

- #194 Handle user initals better if they don't exist
- #190 Clear deletion confirmation text when the require phrase changes and on successful delete
- Sort all networks, tables, and workspaces alphabetically
- Only show skeletons when they're needed in table detail
- Use the same menu with permissions and AQL editor wherever the menu icon appears
- Disable the create network and table buttons when a user has clicked them (I've seen users click multiple time creating multiple upload objects)
- Fix up the logic for file upload handling so it clears properly when a file is removed/added. This change improves the code readability
- Make the error messages on workspace rename and table upload failure more verbose