### PR TITLE
Prefer vueitfy DataPagination type

### DIFF
--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -123,20 +123,12 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { DataPagination } from 'vuetify';
 
 import api from '@/api';
 import { KeyValue, TableRow } from '@/types';
 import store from '@/store';
 import WorkspaceOptionMenu from '@/components/WorkspaceOptionMenu.vue';
-
-interface DataPagination {
-  page: number;
-  itemsPerPage: number;
-  pageStart: number;
-  pageStop: number;
-  pageCount: number;
-  itemsLength: number;
-}
 
 export default Vue.extend({
   name: 'TableDetail',


### PR DESCRIPTION
Closes #32

Use the vuetify pagination type instead of the same definition in our code. This was flagged for removal with vuetify>= 2.2 and it seems our yarn.lock puts us at 2.5.8.

If I need to bump the minimum version in package.json from 2.1.5 to 2.2.0, let me know.