### PR TITLE
Re-enable table sorting by fixing UI in table-detail.vue

### DIFF
--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -89,7 +89,6 @@
           height="calc(100vh - 123px)"
           class="table-details"
           :headers="dataTableHeaders"
-          hide-default-header
           :items="dataTableRows"
           :footer-props="{
             itemsPerPageOptions: [10, 20, 50, 100],
@@ -98,24 +97,7 @@
           :server-items-length="tableSize"
           :options.sync="pagination"
           :loading="loading"
-        >
-          <template v-slot:header>
-            <thead dark>
-              <tr>
-                <th
-                  v-for="(header, i) in dataTableHeaders"
-                  :key="i"
-                  class="pt-2 pb-2"
-                >
-                  {{ header.text }}
-                  <span v-if="columnTypes[header.text]">
-                    ({{ columnTypes[header.text] }})
-                  </span>
-                </th>
-              </tr>
-            </thead>
-          </template>
-        </v-data-table>
+        />
       </div>
     </v-main>
   </v-container>
@@ -168,7 +150,7 @@ export default Vue.extend({
       } = this;
 
       return headers.map((header: Array<keyof TableRow>) => ({
-        text: header,
+        text: this.columnTypes[header] === undefined ? header : `${header} (${this.columnTypes[header]})`,
         value: header,
       }));
     },

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -205,8 +205,8 @@ export default Vue.extend({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     options: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handler(this: any) {
-        this.update();
+      handler(this: any, newValue: DataOptions, oldValue: DataOptions) {
+        this.update(newValue, oldValue);
       },
       deep: true,
     },
@@ -222,16 +222,18 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async update(this: any) {
-      const {
-        options,
-      } = this;
+    async update(this: any, newValue: DataOptions, oldValue: DataOptions) {
+      const changed = (Object.keys(newValue) as (keyof DataOptions)[]).filter((key) => newValue[key] !== oldValue[key]);
+
+      if (changed.includes('sortBy') || changed.includes('sortDesc')) {
+        this.options.page = 1;
+      }
 
       this.loading = true;
 
       const result = await api.table(this.workspace, this.table, {
-        offset: (options.page - 1) * options.itemsPerPage,
-        limit: options.itemsPerPage,
+        offset: (newValue.page - 1) * newValue.itemsPerPage,
+        limit: newValue.itemsPerPage,
       });
 
       const {

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -95,7 +95,7 @@
             showFirstLastPage: true,
           }"
           :server-items-length="tableSize"
-          :options.sync="pagination"
+          :options.sync="options"
           :loading="loading"
         />
       </div>
@@ -105,7 +105,7 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import { DataPagination } from 'vuetify';
+import { DataOptions } from 'vuetify';
 
 import api from '@/api';
 import { KeyValue, TableRow } from '@/types';
@@ -136,7 +136,7 @@ export default Vue.extend({
       headers: [] as Array<keyof TableRow>,
       editing: false,
       tableSize: 1,
-      pagination: {} as DataPagination,
+      options: {} as DataOptions,
       loading: true,
       loadingTables: true,
     };
@@ -203,8 +203,12 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    pagination(this: any) {
-      this.update();
+    options: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler(this: any) {
+        this.update();
+      },
+      deep: true,
     },
   },
 
@@ -220,14 +224,14 @@ export default Vue.extend({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async update(this: any) {
       const {
-        pagination,
+        options,
       } = this;
 
       this.loading = true;
 
       const result = await api.table(this.workspace, this.table, {
-        offset: (pagination.page - 1) * pagination.itemsPerPage,
-        limit: pagination.itemsPerPage,
+        offset: (options.page - 1) * options.itemsPerPage,
+        limit: options.itemsPerPage,
       });
 
       const {

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -149,7 +149,7 @@ export default Vue.extend({
         headers,
       } = this;
 
-      return headers.map((header: Array<keyof TableRow>) => ({
+      return headers.map((header: keyof TableRow) => ({
         text: this.columnTypes[header] === undefined ? header : `${header} (${this.columnTypes[header]})`,
         value: header,
       }));

--- a/src/views/TableDetail.vue
+++ b/src/views/TableDetail.vue
@@ -205,8 +205,8 @@ export default Vue.extend({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     options: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handler(this: any, newValue: DataOptions, oldValue: DataOptions) {
-        this.update(newValue, oldValue);
+      handler(this: any, newValue: DataOptions) {
+        this.update(newValue);
       },
       deep: true,
     },
@@ -222,13 +222,7 @@ export default Vue.extend({
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async update(this: any, newValue: DataOptions, oldValue: DataOptions) {
-      const changed = (Object.keys(newValue) as (keyof DataOptions)[]).filter((key) => newValue[key] !== oldValue[key]);
-
-      if (changed.includes('sortBy') || changed.includes('sortDesc')) {
-        this.options.page = 1;
-      }
-
+    async update(this: any, newValue: DataOptions) {
       this.loading = true;
 
       const result = await api.table(this.workspace, this.table, {


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #57

### Give a longer description of what this PR addresses and why it's needed
This PR fixes table sorting by not overwriting the original vuetify header, instead choosing to amend the text that the header displays. This allows the vuetify sorting hooks to be used and means we don't need to re-invent the wheel. 

### Provide pictures/videos of the behavior before and after these changes (optional)
Here's a photo of after the changes, note that the headers have their types (except _key, see TODOs) and that they have sorting icons. The sorting triggers an API call.
![image](https://user-images.githubusercontent.com/36867477/146092968-c716030e-64e6-41b7-880c-b4942243a09f.png)

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [ ] Make sorting work in multinetjs and in multinet-api. There doesn't seem to be a way to pass through sorting variables
- [ ] See if _key is always missing or if it's just this one table
- [ ] Check if this works with large tables