### PR TITLE
Get table names from tables and networks for AQLWizard

### DIFF
--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -154,9 +154,9 @@ export default {
     };
   },
   computed: {
-    nodeTables: () => store.getters.nodeTables,
-    edgeTables: () => store.getters.edgeTables,
-    networks: () => store.getters.networks,
+    nodeTables: () => store.getters.nodeTables.map((table) => table.name),
+    edgeTables: () => store.getters.edgeTables.map((table) => table.name),
+    networks: () => store.getters.networks.map((network) => network.name),
     workspaceInfo() {
       return [
         { title: 'Node Tables', data: this.nodeTables },

--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -60,9 +60,9 @@
           <v-btn
             color="error"
             text
-            @click="query=''"
+            @click="lastQueryResults=null"
           >
-            Clear
+            Clear Results
           </v-btn>
           <v-spacer />
           <v-btn


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #119
Fixes bug I noticed when using interface (JS objects in the AQL right sidebar)

### Give a longer description of what this PR addresses and why it's needed
This PR fixes a bug from the AQL sidebar and modifies the action of the `clear` button.

I noticed that there were JS objects in the AQL wizard's right sidebar, so this just applied a map the object that it relies on to get just the names from the table objects.

The clear button, now renamed `clear results` now clears the results instead of the query text, as discussed in #119.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![image](https://user-images.githubusercontent.com/36867477/179848116-5f616300-44e3-45c5-8833-d57fc2b7816e.png)

After:
![image](https://user-images.githubusercontent.com/36867477/179848068-995c911e-2387-4bce-99d7-f0a6043710c8.png)

### Are there any additional TODOs before this PR is ready to go?
No