### PR TITLE
Migrate all components to the composition API

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "multinet": "0.21.5",
     "papaparse": "^5.3.0",
     "vue": "^2.7.0",
-    "vue-async-computed": "^3.8.2",
     "vue-gtag": "^1.2.1",
     "vue-json-pretty": "^1.6.4",
     "vue-router": "^3.0.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,39 +26,41 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
 import Sidebar from '@/components/Sidebar.vue';
 import apps from '@/assets/appregistry.json';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'App',
 
   components: {
     Sidebar,
   },
 
-  data() {
+  setup() {
+    const collabs = [
+      {
+        // eslint-disable-next-line global-require
+        logo: require('./assets/logo/utah_logo.png'),
+      },
+      {
+        // eslint-disable-next-line global-require
+        logo: require('./assets/logo/Kitware_Logo.png'),
+      },
+      {
+        // eslint-disable-next-line global-require
+        logo: require('./assets/logo/vdl_logo.png'),
+      },
+      {
+        // eslint-disable-next-line global-require
+        logo: require('./assets/logo/nsf_logo.png'),
+      },
+    ];
+
     return {
       apps,
-      collabs: [
-        {
-          // eslint-disable-next-line global-require
-          logo: require('./assets/logo/utah_logo.png'),
-        },
-        {
-          // eslint-disable-next-line global-require
-          logo: require('./assets/logo/Kitware_Logo.png'),
-        },
-        {
-          // eslint-disable-next-line global-require
-          logo: require('./assets/logo/vdl_logo.png'),
-        },
-        {
-          // eslint-disable-next-line global-require
-          logo: require('./assets/logo/nsf_logo.png'),
-        },
-      ],
+      collabs,
     };
   },
 });

--- a/src/components/AExt.vue
+++ b/src/components/AExt.vue
@@ -9,9 +9,9 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
-export default Vue.extend({
+export default defineComponent({
   props: {
     href: {
       type: String as PropType<string>,

--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -22,18 +22,19 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, ref } from 'vue';
 
 import AboutText from '@/components/AboutText.vue';
 
-export default Vue.extend({
+export default defineComponent({
   components: {
     AboutText,
   },
 
-  data() {
+  setup() {
+    const dialog = ref(false);
     return {
-      dialog: false,
+      dialog,
     };
   },
 });

--- a/src/components/AboutText.vue
+++ b/src/components/AboutText.vue
@@ -44,11 +44,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from 'vue';
 
 import AExt from '@/components/AExt.vue';
 
-export default Vue.extend({
+export default defineComponent({
   components: {
     AExt,
   },

--- a/src/components/AboutText.vue
+++ b/src/components/AboutText.vue
@@ -15,7 +15,7 @@
       <a-ext href="https://vdl.sci.utah.edu/mvnv/">multivariate networks</a-ext>.
       Learn more and explore the code at
       <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
-      <a-ext href="https://github.com/multinet-app/multinet">GitHub</a-ext>.
+      <a-ext href="https://github.com/multinet-app/multinet-api">GitHub</a-ext>.
     </v-card-text>
 
     <v-card-text class="px-4 pt-4 pb-1">
@@ -23,7 +23,7 @@
       <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
       <a-ext href="https://multinet-app.readthedocs.io">documentation</a-ext>,
       <!-- eslint-disable-next-line vue/singleline-html-element-content-newline -->
-      or the <a-ext href="https://api.multinet.app/apidocs">API docs</a-ext>.
+      or the <a-ext href="https://api.multinet.app/swagger">API docs</a-ext>.
     </v-card-text>
 
     <v-divider />

--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -64,8 +64,10 @@
 import oauthClient from '@/oauth';
 import store from '@/store';
 import {
-  computed, defineComponent, getCurrentInstance, ref, watch,
+  computed, defineComponent, ref, watch,
 } from 'vue';
+
+import { useCurrentInstance } from '@/utils/use';
 
 export default defineComponent({
   setup() {
@@ -86,8 +88,8 @@ export default defineComponent({
       oauthClient.redirectToLogin();
     }
 
-    const currentInstance = getCurrentInstance();
-    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
+    const currentInstance = useCurrentInstance();
+    const router = currentInstance.proxy.$router;
     async function logout() {
       // Perform the logout action, then redirect the user to the home page.
       // This is to prevent the logged-out user from continuing to look at, e.g.,

--- a/src/components/NetworkDialog.vue
+++ b/src/components/NetworkDialog.vue
@@ -71,14 +71,16 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import {
+  computed, defineComponent, PropType, ref,
+} from 'vue';
 
 import NetworkCreateForm from '@/components/NetworkCreateForm.vue';
 import NetworkUploadForm from '@/components/NetworkUploadForm.vue';
 import NetworkMultiCSVUploadForm from '@/components/NetworkMultiCSVUploadForm.vue';
 import store from '@/store';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'NetworkDialog',
   components: {
     NetworkCreateForm,
@@ -96,26 +98,27 @@ export default Vue.extend({
       required: true,
     },
   },
-  data() {
+  setup(props, { emit }) {
+    const networkDialog = ref(false);
+    const CSVNetworkDialog = ref(false);
+
+    const userCanEdit = computed(() => store.getters.userCanEdit);
+
+    function networkDialogSuccess() {
+      networkDialog.value = false;
+      emit('success');
+    }
+    function CSVNetworkDialogSuccess() {
+      CSVNetworkDialog.value = false;
+      emit('success');
+    }
     return {
-      networkDialog: false,
-      CSVNetworkDialog: false,
+      networkDialog,
+      CSVNetworkDialog,
+      userCanEdit,
+      networkDialogSuccess,
+      CSVNetworkDialogSuccess,
     };
-  },
-  computed: {
-    userCanEdit(): boolean {
-      return store.getters.userCanEdit;
-    },
-  },
-  methods: {
-    networkDialogSuccess() {
-      this.networkDialog = false;
-      this.$emit('success');
-    },
-    CSVNetworkDialogSuccess() {
-      this.CSVNetworkDialog = false;
-      this.$emit('success');
-    },
   },
 });
 </script>

--- a/src/components/NetworkMultiCSVUploadForm.vue
+++ b/src/components/NetworkMultiCSVUploadForm.vue
@@ -95,8 +95,8 @@
                     dark
                     hide-details
                     class="ma-0 pa-0"
-                    :disabled="edgeTable?.table && edgeTable.table.name !== sample.table.name"
-                    :value="edgeTable?.table.name === sample.table.name"
+                    :disabled="edgeTable.table && edgeTable.table.name !== sample.table.name"
+                    :value="edgeTable.table.name === sample.table.name"
                     @change="setEdgeTable(sample.table, $event)"
                   />
                 </v-row>
@@ -140,7 +140,7 @@
 
                         <!-- Link to other table column -->
                         <v-menu
-                          v-if="mainTables.some((t) => t?.name === sample.table.name)"
+                          v-if="mainTables.some((t) => t.name === sample.table.name)"
                           :close-on-content-click="false"
                           @input="menuOpen = $event"
                         >
@@ -219,7 +219,7 @@
                         </v-menu>
 
                         <v-menu
-                          v-if="inNetworkTables.some((t) => t?.name === sample.table.name)"
+                          v-if="inNetworkTables.some((t) => t.name === sample.table.name)"
                           :close-on-content-click="false"
                           @input="menuOpen = $event"
                         >

--- a/src/components/NetworkMultiCSVUploadForm.vue
+++ b/src/components/NetworkMultiCSVUploadForm.vue
@@ -364,7 +364,7 @@ interface CSVPreview {
 }
 
 export default defineComponent({
-  setup(props, ctx) {
+  setup(props, { emit }) {
     const workspace = computed(() => store.state.currentWorkspace);
 
     const files = ref<File[]>([]);
@@ -927,7 +927,7 @@ export default defineComponent({
       // Create network with post request
       await api.axios.post(`/workspaces/${store.state.currentWorkspace.name}/networks/from_tables/`, network);
       networkCreating.value = false;
-      ctx.emit('success');
+      emit('success');
     }
 
     return {

--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -67,7 +67,7 @@
           >
             <v-list-item-action @click.prevent>
               <v-icon
-                v-if="!hover && !checkbox[item]"
+                v-if="!hover && !checkbox[item.name]"
                 class="item-icon"
               >
                 timeline
@@ -167,7 +167,7 @@ export default defineComponent({
     }
 
     const checkbox: Ref<CheckboxTable> = ref({});
-    const singleSelected: Ref<string | null> = ref('');
+    const singleSelected: Ref<string | null> = ref(null);
     const selectedVisApps = ref(new Array(props.items.length));
 
     const checked = computed(() => Object.keys(checkbox.value).filter((d) => !!checkbox.value[d]));

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -121,8 +121,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { UserSpec } from 'multinet';
+import {
+  computed, defineComponent, getCurrentInstance, Ref, ref, watch,
+} from 'vue';
 
 import store from '@/store';
 
@@ -135,96 +136,76 @@ interface CheckboxTable {
   [index: string]: boolean;
 }
 
-export default Vue.extend({
-
+export default defineComponent({
   components: {
     DeleteWorkspaceDialog,
     WorkspaceDialog,
     AboutDialog,
     LoginMenu,
   },
-  data() {
-    return {
-      newWorkspace: '',
-      checkbox: {} as CheckboxTable,
-      loading: true,
-      singleSelected: null as string | null,
-      tabSelected: 1,
-    };
-  },
 
-  computed: {
-    workspaces: () => store.state.workspaces,
+  setup() {
+    const newWorkspace = ref('');
+    const checkbox: Ref<CheckboxTable> = ref({});
+    const loading = ref(true);
+    const singleSelected: Ref<string | null> = ref(null);
+    const tabSelected = ref(1);
 
-    userInfo(): UserSpec | null {
-      return store.state.userInfo;
-    },
+    const workspaces = computed(() => store.state.workspaces);
+    const userInfo = computed(() => store.state.userInfo);
+    const somethingChecked = computed(() => Object.values(checkbox.value).some(Boolean));
+    const checked = computed(() => Object.keys(checkbox.value).filter((d) => !!checkbox.value[d]));
+    const currentInstance = getCurrentInstance();
+    const navHeight = computed(() => (currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.height - 62 : 0));
+    const selection = computed(() => (singleSelected.value ? [singleSelected.value] : checked.value));
 
-    somethingChecked(): boolean {
-      return Object.values(this.checkbox)
-        .some(Boolean);
-    },
-
-    checked(): string[] {
-      const {
-        checkbox,
-      } = this;
-
-      return Object.keys(checkbox).filter((d) => !!checkbox[d]);
-    },
-
-    navHeight(): number {
-      return this.$vuetify.breakpoint.height - 62; // 62 is height of footer
-    },
-
-    selection(): string[] {
-      const {
-        checked,
-        singleSelected,
-      } = this;
-
-      if (singleSelected) {
-        return [singleSelected];
-      }
-
-      return checked;
-    },
-  },
-
-  watch: {
-    userInfo(newUserInfo) {
+    watch(userInfo, (newUserInfo) => {
       if (newUserInfo !== null) {
-        this.tabSelected = 0;
+        tabSelected.value = 0;
       } else {
-        this.tabSelected = 1;
+        tabSelected.value = 1;
       }
-    },
-  },
+    });
 
-  async created() {
-    try {
-      await store.dispatch.fetchWorkspaces();
-    } finally {
-      this.loading = false;
+    store.dispatch.fetchWorkspaces().then(() => { loading.value = false; });
+
+    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
+    function route(workspace: string) {
+      if (router !== null) {
+        router.push(`/workspaces/${workspace}`);
+      }
     }
-  },
 
-  methods: {
-    route(workspace: string) {
-      this.$router.push(`/workspaces/${workspace}`);
-    },
+    function workspaceDeleted() {
+      checkbox.value = {};
+      if (router !== null) {
+        router.replace({ name: 'home' });
+      }
+    }
 
-    workspaceDeleted() {
-      this.checkbox = {};
-      this.$router.replace({ name: 'home' });
-    },
-
-    deleteWorkspace(ws: string) {
-      this.singleSelected = ws;
+    const dws = ref(null);
+    function deleteWorkspace(ws: string) {
+      singleSelected.value = ws;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.$refs.dws as any).dialog = true;
-    },
+      (dws as any).dialog = true;
+    }
+
+    return {
+      newWorkspace,
+      checkbox,
+      loading,
+      singleSelected,
+      tabSelected,
+      workspaces,
+      somethingChecked,
+      navHeight,
+      selection,
+      userInfo,
+      route,
+      workspaceDeleted,
+      deleteWorkspace,
+    };
   },
 });
 </script>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -122,7 +122,7 @@
 
 <script lang="ts">
 import {
-  computed, defineComponent, getCurrentInstance, Ref, ref, watch,
+  computed, defineComponent, Ref, ref, watch,
 } from 'vue';
 
 import store from '@/store';
@@ -131,6 +131,7 @@ import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
 import DeleteWorkspaceDialog from '@/components/DeleteWorkspaceDialog.vue';
 import AboutDialog from '@/components/AboutDialog.vue';
 import LoginMenu from '@/components/LoginMenu.vue';
+import { useCurrentInstance } from '@/utils/use';
 
 interface CheckboxTable {
   [index: string]: boolean;
@@ -155,8 +156,8 @@ export default defineComponent({
     const userInfo = computed(() => store.state.userInfo);
     const somethingChecked = computed(() => Object.values(checkbox.value).some(Boolean));
     const checked = computed(() => Object.keys(checkbox.value).filter((d) => !!checkbox.value[d]));
-    const currentInstance = getCurrentInstance();
-    const navHeight = computed(() => (currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.height - 62 : 0));
+    const currentInstance = useCurrentInstance();
+    const navHeight = computed(() => (currentInstance.proxy.$vuetify.breakpoint.height - 62));
     const selection = computed(() => (singleSelected.value ? [singleSelected.value] : checked.value));
 
     watch(userInfo, (newUserInfo) => {
@@ -169,7 +170,7 @@ export default defineComponent({
 
     store.dispatch.fetchWorkspaces().then(() => { loading.value = false; });
 
-    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
+    const router = currentInstance.proxy.$router;
     function route(workspace: string) {
       if (router !== null) {
         router.push(`/workspaces/${workspace}`);

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -154,7 +154,7 @@ export default defineComponent({
     }
 
     const checkbox: Ref<CheckboxTable> = ref({});
-    const singleSelected: Ref<string | null> = ref('');
+    const singleSelected: Ref<string | null> = ref(null);
 
     const checked = computed(() => Object.keys(checkbox.value).filter((d) => !!checkbox.value[d]));
     const selection = computed(() => (singleSelected.value !== null ? [singleSelected.value] : [...checked.value]));

--- a/src/components/WorkspaceDialog.vue
+++ b/src/components/WorkspaceDialog.vue
@@ -72,55 +72,63 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {
+  computed, defineComponent, getCurrentInstance, ref, watch,
+} from 'vue';
+// import { useRouter } from 'vue-router';
 
 import api from '@/api';
 import store from '@/store';
 
-export default Vue.extend({
-  data() {
-    return {
-      dialog: false,
-      newWorkspace: '',
-      error: '',
-    };
-  },
+export default defineComponent({
+  setup() {
+    const dialog = ref(false);
+    const newWorkspace = ref('');
+    const error = ref('');
 
-  computed: {
-    userInfo: () => store.state.userInfo,
-  },
+    const userInfo = computed(() => store.state.userInfo);
 
-  watch: {
-    dialog() {
-      if (this.dialog) {
-        this.error = '';
+    watch(dialog, () => {
+      if (dialog.value) {
+        error.value = '';
       }
-    },
-  },
+    });
 
-  methods: {
-    async create() {
-      if (this.newWorkspace) {
+    const instance = getCurrentInstance();
+    // const router = useRouter();
+    async function create() {
+      if (newWorkspace.value) {
         try {
-          const response = await api.createWorkspace(this.newWorkspace);
+          const response = await api.createWorkspace(newWorkspace.value);
 
           if (response) {
             store.dispatch.fetchWorkspaces();
 
-            this.$router.push(`/workspaces/${this.newWorkspace}`);
-            this.newWorkspace = '';
-            this.dialog = false;
+            if (instance !== null) {
+              instance.proxy.$router.push(`/workspaces/${newWorkspace.value}`);
+            }
+
+            newWorkspace.value = '';
+            dialog.value = false;
           }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
           if (err.status === 409) {
-            this.error = `Workspace "${err.data}" already exists!`;
+            error.value = `Workspace "${err.data}" already exists!`;
           } else {
-            this.error = `Error creating workspace: ${err.status}`;
+            error.value = `Error creating workspace: ${err.status}`;
           }
         }
       }
-    },
+    }
+
+    return {
+      dialog,
+      newWorkspace,
+      error,
+      userInfo,
+      create,
+    };
   },
 });
 </script>

--- a/src/components/WorkspaceDialog.vue
+++ b/src/components/WorkspaceDialog.vue
@@ -73,12 +73,13 @@
 
 <script lang="ts">
 import {
-  computed, defineComponent, getCurrentInstance, ref, watch,
+  computed, defineComponent, ref, watch,
 } from 'vue';
 // import { useRouter } from 'vue-router';
 
 import api from '@/api';
 import store from '@/store';
+import { useCurrentInstance } from '@/utils/use';
 
 export default defineComponent({
   setup() {
@@ -94,8 +95,7 @@ export default defineComponent({
       }
     });
 
-    const instance = getCurrentInstance();
-    // const router = useRouter();
+    const router = useCurrentInstance().proxy.$router;
     async function create() {
       if (newWorkspace.value) {
         try {
@@ -104,9 +104,7 @@ export default defineComponent({
           if (response) {
             store.dispatch.fetchWorkspaces();
 
-            if (instance !== null) {
-              instance.proxy.$router.push(`/workspaces/${newWorkspace.value}`);
-            }
+            router.push(`/workspaces/${newWorkspace.value}`);
 
             newWorkspace.value = '';
             dialog.value = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import 'material-design-icons-iconfont/dist/material-design-icons.css';
-import AsyncComputed from 'vue-async-computed';
 import Vue from 'vue';
 import App from './App.vue';
 import api from './api';
@@ -10,7 +9,6 @@ import store from './store';
 import './vuegtag';
 
 Vue.config.productionTip = false;
-Vue.use(AsyncComputed);
 
 oauthClient.maybeRestoreLogin().then(() => {
   Object.assign(api.axios.defaults.headers.common, oauthClient.authHeaders);

--- a/src/utils/use.ts
+++ b/src/utils/use.ts
@@ -1,0 +1,11 @@
+import { getCurrentInstance } from 'vue';
+
+export function useCurrentInstance() {
+  const instance = getCurrentInstance();
+
+  if (instance === null) {
+    throw new Error('Current Vue Instance is null!');
+  }
+
+  return instance;
+}

--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -121,16 +121,20 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import VueJsonPretty from 'vue-json-pretty';
-import { PropType } from 'vue';
+import {
+  computed,
+  defineComponent, getCurrentInstance, PropType, Ref, ref, watch,
+} from 'vue';
 import api from '@/api';
 import store from '@/store';
+import { Location } from 'vue-router';
 
 // eslint-disable-next-line no-use-before-define
 type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
 interface JsonMap { [key: string]: AnyJson }
 type JsonArray = Array<AnyJson>
 
-export default {
+export default defineComponent({
   name: 'AQLWizard',
   components: {
     VueJsonPretty,
@@ -141,109 +145,115 @@ export default {
       required: true,
     },
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data(this: any) {
-    return {
-      query: this.$route.query.query || '',
-      lastQueryResults: null as null | Array<JsonArray>,
-      loading: false,
-      queryErrorMessage: '',
-      createTableMenu: false,
-      createTableErrorMessage: null as null | string,
-      createTableName: null as null | string,
-    };
-  },
-  computed: {
-    nodeTables: () => store.getters.nodeTables,
-    edgeTables: () => store.getters.edgeTables,
-    networks: () => store.getters.networks,
-    workspaceInfo() {
-      return [
-        { title: 'Node Tables', data: this.nodeTables },
-        { title: 'Edge Tables', data: this.edgeTables },
-        { title: 'Networks', data: this.networks, network: true },
-      ];
-    },
-  },
-  watch: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    nodeTables(this: any, nodeTables: string[]) {
-      // Populate text area with example query
-      if (nodeTables.length && !this.query) {
-        this.query = `FOR doc in ${nodeTables[0]} RETURN doc`;
-      }
-    },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    query(this: any, query: string) {
-      if (this.queryErrorMessage) { this.queryErrorMessage = ''; }
+  setup(props) {
+    const lastQueryResults: Ref<null | Array<JsonArray>> = ref(null);
+    const loading = ref(false);
+    const queryErrorMessage = ref('');
+    const createTableMenu = ref(false);
+    const createTableErrorMessage: Ref<null | string> = ref(null);
+    const createTableName: Ref<null | string> = ref(null);
 
-      if (query !== this.$route.query) {
-        const route = {
-          ...this.$route,
+    const currentInstance = getCurrentInstance();
+    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
+    const route = router !== null ? router.currentRoute : null;
+
+    const query = ref(route === null ? '' : route.query.query as string);
+    watch(query, () => {
+      if (queryErrorMessage.value) { queryErrorMessage.value = ''; }
+
+      if (route !== null && query.value !== route.query.query) {
+        const newRoute: Location = {
+          ...route,
+          name: route.name === null ? undefined : route.name,
           query: {
-            ...this.$route.query,
-            query: query || undefined,
+            ...route.query,
+            query: query.value || undefined,
           },
         };
 
-        this.$router.replace(route);
+        if (router !== null) {
+          router.replace(newRoute);
+        }
       }
-    },
-  },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  created(this: any) {
-    store.dispatch.fetchWorkspace(this.workspace);
-  },
-  methods: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    detailLink(this: any, name: string, network: boolean) {
-      const { workspace } = this;
-      const route = network ? 'networkDetail' : 'tableDetail';
+    });
 
-      return { name: route, params: { workspace, table: name, network: name } };
-    },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async createTable(this: any) {
-      const { workspace, query, createTableName } = this;
+    const nodeTables = computed(() => store.getters.nodeTables);
+    watch(nodeTables, () => {
+      if (nodeTables.value.length && !query.value) {
+        query.value = `FOR doc in ${nodeTables.value[0]} RETURN doc`;
+      }
+    });
 
+    const edgeTables = computed(() => store.getters.edgeTables);
+    const networks = computed(() => store.getters.networks);
+    const workspaceInfo = computed(() => [
+      { title: 'Node Tables', data: nodeTables.value },
+      { title: 'Edge Tables', data: edgeTables.value },
+      { title: 'Networks', data: networks.value, network: true },
+    ]);
+
+    function detailLink(name: string, network: boolean) {
+      const routeName = network ? 'networkDetail' : 'tableDetail';
+
+      return { name: routeName, params: { workspace: props.workspace, table: name, network: name } };
+    }
+    async function createTable() {
+      if (createTableName.value === null) {
+        return;
+      }
       try {
-        await api.createAQLTable(workspace, createTableName, query);
-        this.createTableMenu = false;
-        store.dispatch.fetchWorkspace(this.workspace);
+        await api.createAQLTable(props.workspace, createTableName.value, query.value);
+        createTableMenu.value = false;
+        store.dispatch.fetchWorkspace(props.workspace);
 
-        this.$router.push({ name: 'tableDetail', params: { workspace, table: createTableName } });
+        if (router !== null) {
+          router.push({ name: 'tableDetail', params: { workspace: props.workspace, table: createTableName.value } });
+        }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         if (error.status === 409) {
-          this.createTableErrorMessage = 'Table Already Exists';
+          createTableErrorMessage.value = 'Table Already Exists';
         } else {
-          this.createTableErrorMessage = error.data;
+          createTableErrorMessage.value = error.data;
         }
       }
-    },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async runQuery(this: any) {
-      const { workspace, query } = this;
-
-      if (!query) {
-        this.queryErrorMessage = 'Query cannot be empty.';
+    }
+    async function runQuery() {
+      if (!query.value) {
+        queryErrorMessage.value = 'Query cannot be empty.';
         return;
       }
 
-      this.loading = true;
+      loading.value = true;
 
       try {
-        const resp = await api.aql(workspace, query);
-        this.lastQueryResults = resp;
-        this.queryErrorMessage = '';
+        const resp = await api.aql(props.workspace, query.value);
+        lastQueryResults.value = resp;
+        queryErrorMessage.value = '';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
-        this.queryErrorMessage = error.data;
-        this.lastQueryResults = null;
+        queryErrorMessage.value = error.data;
+        lastQueryResults.value = null;
       }
 
-      this.loading = false;
-    },
+      loading.value = false;
+    }
+
+    store.dispatch.fetchWorkspace(props.workspace);
+
+    return {
+      query,
+      lastQueryResults,
+      loading,
+      queryErrorMessage,
+      createTableMenu,
+      createTableErrorMessage,
+      createTableName,
+      workspaceInfo,
+      detailLink,
+      createTable,
+      runQuery,
+    };
   },
-};
+});
 </script>

--- a/src/views/AQLWizard.vue
+++ b/src/views/AQLWizard.vue
@@ -123,11 +123,12 @@
 import VueJsonPretty from 'vue-json-pretty';
 import {
   computed,
-  defineComponent, getCurrentInstance, PropType, Ref, ref, watch,
+  defineComponent, PropType, Ref, ref, watch,
 } from 'vue';
 import api from '@/api';
 import store from '@/store';
 import { Location } from 'vue-router';
+import { useCurrentInstance } from '@/utils/use';
 
 // eslint-disable-next-line no-use-before-define
 type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
@@ -153,8 +154,7 @@ export default defineComponent({
     const createTableErrorMessage: Ref<null | string> = ref(null);
     const createTableName: Ref<null | string> = ref(null);
 
-    const currentInstance = getCurrentInstance();
-    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
+    const router = useCurrentInstance().proxy.$router;
     const route = router !== null ? router.currentRoute : null;
 
     const query = ref(route === null ? '' : route.query.query as string);

--- a/src/views/FrontPage.vue
+++ b/src/views/FrontPage.vue
@@ -160,12 +160,14 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import {
+  computed, defineComponent, PropType, ref,
+} from 'vue';
 import { App } from '@/types';
 import AboutText from '@/components/AboutText.vue';
 import oauthClient from '@/oauth';
 
-export default Vue.extend({
+export default defineComponent({
   components: { AboutText },
   props: {
     apps: {
@@ -174,60 +176,51 @@ export default Vue.extend({
     },
   },
 
-  data() {
-    return {
-      dialog: false,
-    };
-  },
+  setup(props) {
+    const dialog = ref(false);
 
-  computed: {
-    multiMatrixURL(): string {
-      return `${this.apps.network_visualizations.filter((d) => d.name === 'MultiMatrix')[0].url}`;
-    },
+    const multiMatrixURL = computed(() => `${props.apps.network_visualizations.filter((d) => d.name === 'MultiMatrix')[0].url}`);
+    const multiLinkURL = computed(() => `${props.apps.network_visualizations.filter((d) => d.name === 'MultiLink')[0].url}`);
+    const samples = computed(() => [
+      {
+        title: 'Paul Revere - MultiLink',
+        // eslint-disable-next-line global-require
+        image: require('../assets/placard/boston.jpg'),
+        text: 'Explore the Paul Revere dataset using an interactive and beautiful node-link diagram. Discover the figures coordinating a pivotal event in history!',
+        href: `${multiLinkURL.value}/?workspace=boston&network=boston`,
+      },
+      {
+        title: 'Les Miserables - MultiMatrix',
+        // eslint-disable-next-line global-require
+        image: require('../assets/placard/miserables.jpg'),
+        text: 'Explore the Les Miserables dataset using an interactive adjacency matrix. See the factions and relationships for yourself!',
+        href: `${multiMatrixURL.value}/?workspace=miserables&network=miserables`,
+      },
+      {
+        title: 'Les Miserables - MultiLink',
+        // eslint-disable-next-line global-require
+        image: require('../assets/placard/miserables2.jpg'),
+        text: 'The characters of Les Miserables, laid out in a colorful and interactive node-link diagram.',
+        href: `${multiLinkURL.value}/?workspace=miserables&network=miserables`,
+      },
+      {
+        title: 'Paul Revere - MultiMatrix',
+        // eslint-disable-next-line global-require
+        image: require('../assets/placard/boston2.jpg'),
+        text: 'See the relationships between Paul Revere and his contemporaries through an adjacency matrix layout.',
+        href: `${multiMatrixURL.value}/?workspace=boston&network=boston`,
+      },
+    ]);
 
-    multiLinkURL(): string {
-      return `${this.apps.network_visualizations.filter((d) => d.name === 'MultiLink')[0].url}`;
-    },
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    samples(): Array<{title: string; image: any; text: string; href: string }> {
-      return [
-        {
-          title: 'Paul Revere - MultiLink',
-          // eslint-disable-next-line global-require
-          image: require('../assets/placard/boston.jpg'),
-          text: 'Explore the Paul Revere dataset using an interactive and beautiful node-link diagram. Discover the figures coordinating a pivotal event in history!',
-          href: `${this.multiLinkURL}/?workspace=boston&network=boston`,
-        },
-        {
-          title: 'Les Miserables - MultiMatrix',
-          // eslint-disable-next-line global-require
-          image: require('../assets/placard/miserables.jpg'),
-          text: 'Explore the Les Miserables dataset using an interactive adjacency matrix. See the factions and relationships for yourself!',
-          href: `${this.multiMatrixURL}/?workspace=miserables&network=miserables`,
-        },
-        {
-          title: 'Les Miserables - MultiLink',
-          // eslint-disable-next-line global-require
-          image: require('../assets/placard/miserables2.jpg'),
-          text: 'The characters of Les Miserables, laid out in a colorful and interactive node-link diagram.',
-          href: `${this.multiLinkURL}/?workspace=miserables&network=miserables`,
-        },
-        {
-          title: 'Paul Revere - MultiMatrix',
-          // eslint-disable-next-line global-require
-          image: require('../assets/placard/boston2.jpg'),
-          text: 'See the relationships between Paul Revere and his contemporaries through an adjacency matrix layout.',
-          href: `${this.multiMatrixURL}/?workspace=boston&network=boston`,
-        },
-      ];
-    },
-  },
-
-  methods: {
-    login(): void {
+    function login(): void {
       oauthClient.redirectToLogin();
-    },
+    }
+
+    return {
+      dialog,
+      samples,
+      login,
+    };
   },
 });
 </script>

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -157,7 +157,7 @@
 
 <script lang="ts">
 import {
-  defineComponent, ref, PropType, computed, watch, getCurrentInstance,
+  defineComponent, ref, PropType, computed, watch,
 } from 'vue';
 
 import api from '@/api';
@@ -166,6 +166,7 @@ import NetworkPanel from '@/components/NetworkPanel.vue';
 import store from '@/store';
 import WorkspaceOptionMenu from '@/components/WorkspaceOptionMenu.vue';
 import { App } from '@/types';
+import { useCurrentInstance } from '@/utils/use';
 
 const surroundingWhitespace = /^\s+|\s+$/;
 const workspaceNameRules: Array<(x: string) => string|boolean> = [
@@ -194,8 +195,7 @@ export default defineComponent({
   },
 
   setup(props) {
-    const currentInstance = getCurrentInstance();
-    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
+    const router = useCurrentInstance().proxy.$router;
 
     const localWorkspace = ref<string | null>(null);
     const editing = ref(false);

--- a/src/views/WorkspaceDetail.vue
+++ b/src/views/WorkspaceDetail.vue
@@ -157,7 +157,7 @@
 
 <script lang="ts">
 import {
-  defineComponent, ref, PropType, computed, watch,
+  defineComponent, ref, PropType, computed, watch, getCurrentInstance,
 } from 'vue';
 
 import api from '@/api';
@@ -193,8 +193,9 @@ export default defineComponent({
     },
   },
 
-  setup(props, ctx) {
-    const router = ctx.root.$router;
+  setup(props) {
+    const currentInstance = getCurrentInstance();
+    const router = currentInstance !== null ? currentInstance.proxy.$router : null;
 
     const localWorkspace = ref<string | null>(null);
     const editing = ref(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8526,11 +8526,6 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vue-async-computed@^3.8.2:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/vue-async-computed/-/vue-async-computed-3.9.0.tgz#af3181c25168bfe9d86d8ffbc7033bf9e484fe84"
-  integrity sha512-ac6m/9zxHHNGGKNOU1en8qNk+fAmEbJLuWL7qyQTFuH3vjv3V4urv//QHcVzCobROM6btnaDG2b+XYMncF/ETA==
-
 vue-cli-plugin-vuetify@~2.5.1:
   version "2.5.1"
   resolved "https://registry.npmmirror.com/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.5.1.tgz#6a3ee80c6e8d09b634ec7705422573f2ee0bc7e7"


### PR DESCRIPTION
### Does this PR close any open issues?
Depends on #246 

### Give a longer description of what this PR addresses and why it's needed
This large PR migrates all components over to the composition API.

There were a couple of issues that I ran into when trying to do this conversion that I had to work around. The main one was that `vue-router` doesn't support the composition API on vue 2.x. As such, I have to interact with the router in cumbersome ways (through getCurrentInstance with lots of null checks). This will be fixed in a final vue 2.x compatible release of `vue-router`, when vue-router#3760 is addressed. I will make an issue to track this change.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Make issue for vue-router upgrade (#251)