### PR TITLE
Move checkbox tables type to types.ts

### DIFF
--- a/src/components/NetworkPanel.vue
+++ b/src/components/NetworkPanel.vue
@@ -118,7 +118,7 @@ import NetworkDialog from '@/components/NetworkDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
-import { App } from '@/types';
+import { App, CheckboxTable } from '@/types';
 
 export default defineComponent({
   name: 'NetworkPanel',
@@ -162,10 +162,6 @@ export default defineComponent({
   },
 
   setup(props) {
-    interface CheckboxTable {
-      [index: string]: boolean;
-    }
-
     const checkbox: Ref<CheckboxTable> = ref({});
     const singleSelected: Ref<string | null> = ref(null);
     const selectedVisApps = ref(new Array(props.items.length));

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -131,10 +131,7 @@ import WorkspaceDialog from '@/components/WorkspaceDialog.vue';
 import DeleteWorkspaceDialog from '@/components/DeleteWorkspaceDialog.vue';
 import AboutDialog from '@/components/AboutDialog.vue';
 import LoginMenu from '@/components/LoginMenu.vue';
-
-interface CheckboxTable {
-  [index: string]: boolean;
-}
+import { CheckboxTable } from '@/types';
 
 export default defineComponent({
   components: {

--- a/src/components/TablePanel.vue
+++ b/src/components/TablePanel.vue
@@ -115,7 +115,7 @@ import TableDialog from '@/components/TableDialog.vue';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 
 import store from '@/store';
-import { App } from '@/types';
+import { App, CheckboxTable } from '@/types';
 
 export default defineComponent({
   name: 'TablePanel',
@@ -149,10 +149,6 @@ export default defineComponent({
   },
 
   setup(props) {
-    interface CheckboxTable {
-      [index: string]: boolean;
-    }
-
     const checkbox: Ref<CheckboxTable> = ref({});
     const singleSelected: Ref<string | null> = ref(null);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,10 @@ export interface FileTypeTable {
   [key: string]: FileType;
 }
 
+export interface CheckboxTable {
+  [index: string]: boolean;
+}
+
 export interface Upload {
   blob: string;
   status: 'PENDING' | 'STARTED' | 'FAILED' | 'FINISHED';


### PR DESCRIPTION
### Does this PR close any open issues?
Depends #247 
Closes #245

### Give a longer description of what this PR addresses and why it's needed
Moves the `CheckboxTable` type into types.ts, instead of redefining it in 3 separate places.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No