### PR TITLE
Allow source/target column sharing

### DIFF
--- a/src/components/NetworkMultiCSVUploadForm.vue
+++ b/src/components/NetworkMultiCSVUploadForm.vue
@@ -645,8 +645,7 @@ export default defineComponent({
 
     function getOtherTableColumns(tableName: string) {
       const otherTables = visibleTableSamples.value.filter(
-        // (sample) => !mainTables.value.includes(sample.table.name) && sample.table.name !== tableName,
-        (sample) => !mainTables.value.some((t) => t?.name === sample.table.name) && sample.table.name !== tableName,
+        (sample) => sample.table.name !== tableName,
       );
 
       return otherTables.reduce((prev, cur) => ([


### PR DESCRIPTION
Closes #258 

With this change, you can creating a network in the UI with the following data (not possible before)

Edge table:
```
source,target
1,2
1,3
2,3
```

Node table

```
id,name
1,jack
2,john
3,james
```