### PR TITLE
Add user-specifiable csv delimiters and quote characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dayjs": "^1.9.1",
     "direct-vuex": "^0.10.4",
     "lodash": "^4.17.21",
-    "multinet": "0.21.7",
+    "multinet": "0.21.8",
     "multinet-components": "^0.0.1",
     "papaparse": "^5.3.0",
     "vue": "^2.7.0",

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -158,6 +158,7 @@
               persistent-hint
               hint="Delimiter"
               style="max-width: 100px"
+              class="mr-2"
               @change="delimiterQuoteChanged"
             />
 

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -152,6 +152,13 @@
           </v-data-table>
 
           <v-footer class="py-3">
+            <v-select
+              v-model="delimiter"
+              :items="delimiterOptions"
+              persistent-hint
+              hint="Delimiter"
+              style="max-width: 100px"
+            />
             <v-spacer />
             <v-btn
               color="primary"
@@ -218,6 +225,9 @@ export default defineComponent({
       }));
     });
 
+    const delimiter = ref('');
+    const delimiterOptions = [',', ';', '|', '\\t'];
+
     const edgeTable = computed(() => {
       const sample = sampleRows.value[0] || {};
       const hasFrom = Object.prototype.hasOwnProperty.call(sample, '_from');
@@ -248,6 +258,7 @@ export default defineComponent({
       columnType.value = Array.from(analysis.typeRecs.keys()).reduce((acc, key) => ({ ...acc, [key]: analysis.typeRecs.get(key) }), {});
 
       sampleRows.value = [...analysis.sampleRows];
+      delimiter.value = analysis.delimiter;
     });
 
     // Upload options
@@ -295,6 +306,7 @@ export default defineComponent({
           data: selectedFile.value,
           edgeTable: edgeTable.value,
           columnTypes: columnType.value,
+          delimiter: delimiter.value,
         });
 
         tableCreationError.value = null;
@@ -319,6 +331,8 @@ export default defineComponent({
       dialogWidth,
       headers,
       sampleRows,
+      delimiter,
+      delimiterOptions,
       columnType,
       multinetTypes,
       selectedFile,

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -227,7 +227,7 @@ export default defineComponent({
     });
 
     const delimiter = ref('');
-    const delimiterOptions = [',', ';', '|', '\\t'];
+    const delimiterOptions = [',', ';', '|'];
 
     const edgeTable = computed(() => {
       const sample = sampleRows.value[0] || {};

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -158,8 +158,18 @@
               persistent-hint
               hint="Delimiter"
               style="max-width: 100px"
-              @change="delimiterChanged"
+              @change="delimiterQuoteChanged"
             />
+
+            <v-select
+              v-model="quoteChar"
+              :items="quoteCharOptions"
+              persistent-hint
+              hint="Quote Character"
+              style="max-width: 100px"
+              @change="delimiterQuoteChanged"
+            />
+
             <v-spacer />
             <v-btn
               color="primary"
@@ -229,6 +239,9 @@ export default defineComponent({
     const delimiter = ref('');
     const delimiterOptions = [',', ';', '|'];
 
+    const quoteChar = ref('"');
+    const quoteCharOptions = ['"', '\''];
+
     const edgeTable = computed(() => {
       const sample = sampleRows.value[0] || {};
       const hasFrom = Object.prototype.hasOwnProperty.call(sample, '_from');
@@ -239,8 +252,8 @@ export default defineComponent({
     // Type recommendation
     const columnType: Ref<{[key: string]: CSVColumnType}> = ref({});
 
-    async function runCSVAnalysis(newFile: File, userDelim?: string) {
-      const analysis = await analyzeCSV(newFile, userDelim === undefined ? '' : userDelim);
+    async function runCSVAnalysis(newFile: File, userDelim?: string, userQuote?: string) {
+      const analysis = await analyzeCSV(newFile, userDelim, userQuote);
       columnType.value = Array.from(analysis.typeRecs.keys()).reduce((acc, key) => ({ ...acc, [key]: analysis.typeRecs.get(key) }), {});
 
       sampleRows.value = [...analysis.sampleRows];
@@ -266,10 +279,10 @@ export default defineComponent({
       await runCSVAnalysis(newFile);
     });
 
-    async function delimiterChanged() {
-      // Re-run the analysis with the user-specified delimiter
+    async function delimiterQuoteChanged() {
+      // Re-run the analysis with the user-specified delimiter and quote character
       if (selectedFile.value !== null) {
-        await runCSVAnalysis(selectedFile.value, delimiter.value);
+        await runCSVAnalysis(selectedFile.value, delimiter.value, quoteChar.value);
       }
     }
 
@@ -319,6 +332,7 @@ export default defineComponent({
           edgeTable: edgeTable.value,
           columnTypes: columnType.value,
           delimiter: delimiter.value,
+          quoteChar: quoteChar.value,
         });
 
         tableCreationError.value = null;
@@ -345,7 +359,9 @@ export default defineComponent({
       sampleRows,
       delimiter,
       delimiterOptions,
-      delimiterChanged,
+      quoteChar,
+      quoteCharOptions,
+      delimiterQuoteChanged,
       columnType,
       multinetTypes,
       selectedFile,

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -43,7 +43,7 @@ interface CSVAnalysis {
   delimiter: string;
 }
 
-async function analyzeCSV(file: File, userDelim?: string): Promise<CSVAnalysis> {
+async function analyzeCSV(file: File, userDelim?: string, userQuote?: string): Promise<CSVAnalysis> {
   const parsePromise: Promise<CSVAnalysis> = new Promise((resolve) => {
     const columnTypes = new Map<string, TypeScore>();
     const typeRecs = new Map<string, CSVColumnType>();
@@ -55,6 +55,7 @@ async function analyzeCSV(file: File, userDelim?: string): Promise<CSVAnalysis> 
       header: true,
       skipEmptyLines: true,
       delimiter: userDelim === undefined ? '' : userDelim,
+      quoteChar: userQuote === undefined ? '"' : userQuote,
       step(row: ParseResult<Record<string, unknown>>, parser) {
         // Set the delimiter
         delimiter = row.meta.delimiter;

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -40,6 +40,7 @@ interface TypeScore {
 interface CSVAnalysis {
   typeRecs: Map<string, CSVColumnType>;
   sampleRows: Array<Record<string, unknown>>;
+  delimiter: string;
 }
 
 async function analyzeCSV(file: File): Promise<CSVAnalysis> {
@@ -47,12 +48,16 @@ async function analyzeCSV(file: File): Promise<CSVAnalysis> {
     const columnTypes = new Map<string, TypeScore>();
     const typeRecs = new Map<string, CSVColumnType>();
     const sampleRows = [] as Array<Record<string, unknown>>;
+    let delimiter = '';
     let rowsParsed = 0;
 
     Papa.parse(file, {
       header: true,
       skipEmptyLines: true,
       step(row: ParseResult<Record<string, unknown>>, parser) {
+        // Set the delimiter
+        delimiter = row.meta.delimiter;
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data = row.data as { [key: string]: any };
 
@@ -94,7 +99,7 @@ async function analyzeCSV(file: File): Promise<CSVAnalysis> {
           // convert to 0, so those are excluded specifically. Trim the string
           // here and not above to preserve its literal string value in case
           // it's not a number.
-          if (value.trim() !== '' && !Number.isNaN(Number(value.trim()))) {
+          if (typeof value === 'string' && value.trim() !== '' && !Number.isNaN(Number(value.trim()))) {
             entry.number += 1;
           }
 
@@ -132,6 +137,7 @@ async function analyzeCSV(file: File): Promise<CSVAnalysis> {
         resolve({
           typeRecs,
           sampleRows,
+          delimiter,
         });
       },
     });

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -43,7 +43,7 @@ interface CSVAnalysis {
   delimiter: string;
 }
 
-async function analyzeCSV(file: File): Promise<CSVAnalysis> {
+async function analyzeCSV(file: File, userDelim?: string): Promise<CSVAnalysis> {
   const parsePromise: Promise<CSVAnalysis> = new Promise((resolve) => {
     const columnTypes = new Map<string, TypeScore>();
     const typeRecs = new Map<string, CSVColumnType>();
@@ -54,6 +54,7 @@ async function analyzeCSV(file: File): Promise<CSVAnalysis> {
     Papa.parse(file, {
       header: true,
       skipEmptyLines: true,
+      delimiter: userDelim === undefined ? '' : userDelim,
       step(row: ParseResult<Record<string, unknown>>, parser) {
         // Set the delimiter
         delimiter = row.meta.delimiter;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6102,10 +6102,10 @@ multinet-components@^0.0.1:
   resolved "https://registry.yarnpkg.com/multinet-components/-/multinet-components-0.0.1.tgz#41c2e4c2e716ed37f9b54a6dc0ba03899c16d8e3"
   integrity sha512-M8FSfeZetigiHbHz6bT0OTKT6aV3gzfNJODZGEBoVNp/axRk3aHTLfSJ86/KMxbl5guUvlj+z3n1lXc7yRSC4g==
 
-multinet@0.21.7:
-  version "0.21.7"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.21.7.tgz#657d1f42eff6b628b5472a3845b142644387f1cc"
-  integrity sha512-0wvK9kaYbvQsARQ6uAqmuF1Y+JZchMGyTUGW0nfSSVE2THacD356gEzyz6zr25Rurh49QufrljJHDe7tVP8EAA==
+multinet@0.21.8:
+  version "0.21.8"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.21.8.tgz#a8f6d08480c64a1c38e4874922e82f5e707f1518"
+  integrity sha512-9rXHDUa0B6XKjcwJnAijNTPyvxmm3ZaMgdRxYmSt9fMOKboVBG85JGX65sCpSNA64mJ/6ocplIJhcqOgdHRv1Q==
   dependencies:
     axios "^0.21.1"
     django-s3-file-field "^0.1.2"


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #7 

### Give a longer description of what this PR addresses and why it's needed
This change adds a user-specifiable csv delimiter and quote character. 

The csv analysis that already runs will suggest a delimiter, so I grabbed that as the default recommendation. When the user changes the delimiter and selects a different delimiter, the analysis is re-ran so that the preview is updated.

The quote character is a selection between a couple of options (`"` and `'`). Similarly, this re-runs the analysis so that the preview is updated accordingly.

### Provide pictures/videos of the behavior before and after these changes (optional)
CSV2 before:
![image](https://user-images.githubusercontent.com/36867477/195173269-4ce20370-f5a2-4230-be38-f48bedfaa845.png)

CSV2 after:
![image](https://user-images.githubusercontent.com/36867477/195173299-128650b7-d8e2-4dcf-aa0e-509eadc203e2.png)

Upload UI changes:
![image](https://user-images.githubusercontent.com/36867477/195173346-2e384f67-5027-4858-9c51-e8ac2274a1c9.png)


### Are there any additional TODOs before this PR is ready to go?
TODOs:
- [x] Add quote character selection
- [x] Add pictures of the UI changes