### PR TITLE
Tab delimiter and delimiterOptions

### DIFF
--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -238,7 +238,7 @@ export default defineComponent({
     });
 
     const delimiter = ref('');
-    const delimiterOptions = [',', ';', '|'];
+    const delimiterOptions = [{ text: ',', value: ',' }, { text: ';', value: ';' }, { text: '|', value: '|' }, { text: 'tab', value: '\t' }];
 
     const quoteChar = ref('"');
     const quoteCharOptions = ['"', '\''];


### PR DESCRIPTION
### Give a longer description of what this PR addresses and why it's needed
Adds the tab (\t) delimiter and refactors delimiterOptions to allow different names and values in papaparse.

### Provide pictures/videos of the behavior before and after these changes (optional)
![Screenshot 2022-12-19 at 14-24-36 MultiNet – Visualizing Networks with Attributes](https://user-images.githubusercontent.com/35744963/208527034-fd83ccbb-f77f-4fd2-8b9f-f3b6913de81f.png)