### PR TITLE
Use an intradomain cookie to communicate login credentials

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/vue';
 import Vue from 'vue';
 import App from './App.vue';
 import api from './api';
-import { sentryDsn } from './environment';
 import oauthClient from './oauth';
+import { sentryDsn, oauthClientId } from './environment';
 import vuetify from './vuetify';
 import router from './router';
 import store from './store';
@@ -11,8 +11,23 @@ import './vuegtag';
 
 Vue.config.productionTip = false;
 
+function writeSharedLoginCookie(token: string) {
+  document.cookie = `sharedLogin=${token}; Domain=${window.location.hostname}`;
+}
+
+function invalidateSharedLoginCookie() {
+  document.cookie = `sharedLogin=; Domain=${window.location.hostname}; Max-Age=0`;
+}
+
 oauthClient.maybeRestoreLogin().then(() => {
   Object.assign(api.axios.defaults.headers.common, oauthClient.authHeaders);
+
+  const tokenString = localStorage.getItem(`oauth-token-${oauthClientId}`);
+  if (tokenString) {
+    writeSharedLoginCookie(tokenString);
+  } else {
+    invalidateSharedLoginCookie();
+  }
 
   if (sentryDsn && window.location.hostname !== 'localhost') {
     Sentry.init({


### PR DESCRIPTION
This PR implements a shared login setup using a "domainless" cookie to allow the vis apps to read login credentials from multinet.app's cookie storage.