### PR TITLE
Use shared login functions from multinet library

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "direct-vuex": "^0.10.4",
     "eslint-import-resolver-alias": "^1.1.2",
     "lodash": "^4.17.21",
-    "multinet": "0.21.9",
+    "multinet": "0.21.10",
     "multinet-components": "^0.0.1",
     "papaparse": "^5.3.0",
     "unplugin-vue-components": "^0.23.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/vue';
 import Vue from 'vue';
+import { writeSharedLoginCookie, invalidateSharedLoginCookie } from 'multinet';
 import App from './App.vue';
 import api from './api';
 import oauthClient from './oauth';
@@ -10,14 +11,6 @@ import store from './store';
 import './vuegtag';
 
 Vue.config.productionTip = false;
-
-function writeSharedLoginCookie(token: string) {
-  document.cookie = `sharedLogin=${token}; Domain=${window.location.hostname}`;
-}
-
-function invalidateSharedLoginCookie() {
-  document.cookie = `sharedLogin=; Domain=${window.location.hostname}; Max-Age=0`;
-}
 
 oauthClient.maybeRestoreLogin().then(() => {
   Object.assign(api.axios.defaults.headers.common, oauthClient.authHeaders);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4051,10 +4051,10 @@ multinet-components@^0.0.1:
   resolved "https://registry.yarnpkg.com/multinet-components/-/multinet-components-0.0.1.tgz#41c2e4c2e716ed37f9b54a6dc0ba03899c16d8e3"
   integrity sha512-M8FSfeZetigiHbHz6bT0OTKT6aV3gzfNJODZGEBoVNp/axRk3aHTLfSJ86/KMxbl5guUvlj+z3n1lXc7yRSC4g==
 
-multinet@0.21.9:
-  version "0.21.9"
-  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.21.9.tgz#b7e6ae47671340cf8e4fc3e93cc3b4f4070cfe51"
-  integrity sha512-0Kwnr9SLjzp3qFUbBrAp5zXB17scON3kCO6N9q3wSDT9D14OS0NOVjrRkkoBzqiGB8GeDyhPNJd4SpwIJPLJ1A==
+multinet@0.21.10:
+  version "0.21.10"
+  resolved "https://registry.yarnpkg.com/multinet/-/multinet-0.21.10.tgz#5e5e215cab2650ab940c1c7d52dae1e89806faa4"
+  integrity sha512-dMr4ijRS/RtdSEhJ6Drmd4maE96kUvEODfr+1XBxby8p11sAee+MPoSelXMzvxREmwBMVo4ZXHDotvc9TMCGHw==
   dependencies:
     axios "^0.21.1"
     django-s3-file-field "^0.1.2"


### PR DESCRIPTION
This PR changes the use of private functions to those from multinet-app/multinetjs#77.

Marking this as draft because once multinetjs is released, this branch will need to update the dependent multinetjs version before it can be reviewed and merged.

(See also https://github.com/multinet-app/multilink/pull/347.)