### PR TITLE
No illegal object names for Arango

### DIFF
--- a/src/components/NetworkCreateForm.vue
+++ b/src/components/NetworkCreateForm.vue
@@ -19,6 +19,7 @@
             v-model="newNetwork"
             dense
             :error-messages="networkCreationErrors"
+            :rules="[() => objectNameIsValid(newNetwork) || 'File name must contain only alphanumeric characters or \'-\' or \'_\'. First character must be a letter. Max length 250 characters.']"
             label="Network name"
             outlined
           />
@@ -104,6 +105,7 @@ export default defineComponent({
       loading,
       networkCreateDisabled,
       createNetwork,
+      objectNameIsValid,
     };
   },
 });

--- a/src/components/NetworkCreateForm.vue
+++ b/src/components/NetworkCreateForm.vue
@@ -49,6 +49,7 @@ import {
 } from 'vue';
 
 import api from '@/api';
+import { objectNameIsValid } from '@/utils/validation';
 
 export default defineComponent({
   name: 'NetworkCreateForm',
@@ -69,7 +70,7 @@ export default defineComponent({
     const newNetwork = ref('');
     const loading = ref(false);
 
-    const networkCreateDisabled = computed(() => !networkEdgeTable.value || !newNetwork.value);
+    const networkCreateDisabled = computed(() => !networkEdgeTable.value || !objectNameIsValid(newNetwork.value));
 
     function clear() {
       networkEdgeTable.value = null;

--- a/src/components/NetworkMultiCSVUploadForm.vue
+++ b/src/components/NetworkMultiCSVUploadForm.vue
@@ -20,6 +20,7 @@
       >
         <v-text-field
           v-model="networkName"
+          :rules="[() => objectNameIsValid(networkName) || 'File name must contain only alphanumeric characters or \'-\' or \'_\'. First character must be a letter. Max length 250 characters.']"
           label="Network Name"
           solo
         />
@@ -964,6 +965,7 @@ export default defineComponent({
       valid,
       createNetwork,
       networkCreating,
+      objectNameIsValid,
     };
   },
 });

--- a/src/components/NetworkMultiCSVUploadForm.vue
+++ b/src/components/NetworkMultiCSVUploadForm.vue
@@ -309,6 +309,7 @@ import { DataTableHeader } from 'vuetify';
 
 import api from '@/api';
 import store from '@/store';
+import { objectNameIsValid } from '@/utils/validation';
 
 const LinkColors = [
   'amber',
@@ -877,7 +878,7 @@ export default defineComponent({
 
     // Denotes whether the dialog is in a submittable state
     const valid = computed(() => !!(
-      networkName.value
+      objectNameIsValid(networkName.value)
       && edgeTable.value?.table
       && sourceTable.value
       && targetTable.value

--- a/src/components/NetworkUploadForm.vue
+++ b/src/components/NetworkUploadForm.vue
@@ -57,6 +57,7 @@
       <v-spacer />
       <v-btn
         id="create-table"
+        color="primary"
         :disabled="createDisabled"
         @click="createNetwork"
       >
@@ -78,6 +79,7 @@ import {
 
 import api from '@/api';
 import { NetworkFileType } from '@/types';
+import { objectNameIsValid } from '@/utils/validation';
 
 const fileTypes: NetworkFileType[] = [
   {
@@ -121,7 +123,7 @@ export default defineComponent({
 
     const createDisabled = computed(() => (
       !file.value
-      || !fileName.value
+      || !objectNameIsValid(fileName.value)
       || !selectedType.value
       || !!fileUploadError.value
     ));

--- a/src/components/NetworkUploadForm.vue
+++ b/src/components/NetworkUploadForm.vue
@@ -43,6 +43,7 @@
             id="table-name"
             v-model="fileName"
             dense
+            :rules="[() => objectNameIsValid(fileName) || 'File name must contain only alphanumeric characters or \'-\' or \'_\'. First character must be a letter. Max length 250 characters.']"
             :error-messages="tableCreationError"
             label="Network name"
             outlined
@@ -214,6 +215,7 @@ export default defineComponent({
       handleUploadProgress,
       handleFileInput,
       createNetwork,
+      objectNameIsValid,
     };
   },
 });

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -207,6 +207,7 @@ import api from '@/api';
 import { CSVColumnType } from '@/types';
 import { analyzeCSV, guessJSONColumnTypes } from '@/utils/files';
 import store from '@/store';
+import { objectNameIsValid } from '@/utils/validation';
 
 const defaultKeyField = '_key';
 const multinetTypes: readonly CSVColumnType[] = ['label', 'boolean', 'category', 'number', 'date'];
@@ -332,9 +333,10 @@ export default defineComponent({
       uploadProgress.value = null;
     }
 
+    const createDisabled = computed(() => selectedFile.value === null || !objectNameIsValid(fileName.value));
+
     // Table creation state
     const tableDialog = ref(false);
-    const createDisabled = computed(() => selectedFile.value === null || !fileName.value);
     const loading = ref(false);
     async function createTable() {
       if (selectedFile.value === null || fileName.value === null) {

--- a/src/components/TableDialog.vue
+++ b/src/components/TableDialog.vue
@@ -65,6 +65,7 @@
                     <v-text-field
                       v-model="fileName"
                       label="Table Name"
+                      :rules="[() => objectNameIsValid(fileName) || 'File name must contain only alphanumeric characters or \'-\' or \'_\'. First character must be a letter. Max length 250 characters.']"
                       outlined
                       dense
                     />
@@ -400,6 +401,7 @@ export default defineComponent({
       overwrite,
       userCanEdit,
       fileIsCSV,
+      objectNameIsValid,
     };
   },
 });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,9 @@
+// This regex checks that the first character is a letter and that the following characters are in \w or -. Specials are disallowed
+const objectNameRegex = /([a-zA-Z])([\w-])*/g;
+export function objectNameIsValid(fileName: string | null) {
+  if (fileName !== null) {
+    const regexMatch = fileName.match(objectNameRegex);
+    return regexMatch !== null && regexMatch[0] === fileName && fileName.length < 251; // Arango is 256, but we'll be conservative by limiting to 250
+  }
+  return false;
+}


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
We currently allow illegal Arango names, which leads to network or table upload/creation errors. This is only told to the use after a failed upload. The Arango naming conventions are listed [here](https://www.arangodb.com/docs/stable/data-modeling-naming-conventions-collection-and-view-names.html).

To fix this, I added name validation and some error messages that show the user what is wrong before the creation/upload fails. This is much more robust than what we had previously.

### Provide pictures/videos of the behavior before and after these changes (optional)
<img width="453" alt="Screenshot 2023-03-28 at 3 29 26 PM" src="https://user-images.githubusercontent.com/36867477/228371066-ebc3da33-cf76-49bf-b45a-bb2d48125f27.png">

### Are there any additional TODOs before this PR is ready to go?
No